### PR TITLE
feat: add "Test Your Landing Page" section to home page

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -4,6 +4,7 @@ import { Suspense, useState } from 'react'
 import Constellation from '@/components/ui/Constellation';
 import Header from "@/components/layout/Header";
 import Hero from "@/components/marketing/Hero";
+import LandingPageTest from "@/components/marketing/LandingPageTest";
 import Hello from "@/components/marketing/Hello";
 import Problem from "@/components/marketing/Problem";
 import FeaturesAccordion from "@/components/features/FeaturesAccordion";
@@ -72,6 +73,7 @@ export default function Home() {
       <Constellation />
       <main>
         <Hero />
+        <LandingPageTest />
         <Problem />
         <Hello />
         <TestimonialGrid testimonials={testimonials} />

--- a/components/marketing/LandingPageTest.js
+++ b/components/marketing/LandingPageTest.js
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+
+const LandingPageTest = () => {
+  const [url, setUrl] = useState("");
+
+  const handleTestPage = (e) => {
+    e.preventDefault();
+    const testUrl = url.trim() || window.location.href;
+    const encodedUrl = encodeURIComponent(testUrl);
+    window.open(`https://landingpage.report?url=${encodedUrl}`, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="py-16 md:py-24 px-8 bg-base-200 bg-opacity-80">
+      <div className="max-w-4xl mx-auto text-center">
+        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-primary/10 mb-6">
+          <span>🎯</span>
+          <p className="font-medium text-primary text-sm">Free Tool</p>
+        </div>
+
+        <h2 className="font-extrabold text-3xl lg:text-5xl tracking-tight mb-4">
+          Test Your Landing Page
+        </h2>
+
+        <p className="text-base-content/80 text-lg mb-8 max-w-2xl mx-auto">
+          Get instant feedback on your landing page's effectiveness. Analyze copy, design, and conversion potential with our free Landing Page Report tool.
+        </p>
+
+        <form onSubmit={handleTestPage} className="flex flex-col sm:flex-row gap-4 max-w-xl mx-auto">
+          <input
+            type="url"
+            placeholder="Enter your landing page URL"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className="input input-bordered flex-1 bg-base-100"
+          />
+          <button
+            type="submit"
+            className="btn btn-primary"
+          >
+            Analyze Page
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </button>
+        </form>
+
+        <p className="text-base-content/60 text-sm mt-4">
+          Leave empty to test this page, or enter any URL to analyze
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default LandingPageTest;


### PR DESCRIPTION
Add new LandingPageTest component that integrates with landingpage.report. Users can enter a URL to analyze or test the current page. The tool opens in a new tab with the URL prefilled via query parameter.