### PR TITLE
Fix build errors

### DIFF
--- a/app/api/stripe/create-checkout/route.js
+++ b/app/api/stripe/create-checkout/route.js
@@ -1,9 +1,5 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/libs/next-auth";
 import { createCheckout } from "@/libs/stripe";
-import connectMongo from "@/libs/mongoose";
-import User from "@/models/User";
 
 // This function is used to create a Stripe Checkout Session (one-time payment or subscription)
 // It's called by the <ButtonCheckout /> component

--- a/app/services/page.js
+++ b/app/services/page.js
@@ -6,7 +6,6 @@ import Footer from "@/components/layout/Footer";
 import Constellation from '@/components/ui/Constellation';
 import Modal from "@/components/marketing/Modal";
 import ButtonLead from "@/components/ui/ButtonLead";
-import UkraineCallOut from '@/components/marketing/UkraineCallOut';
 
 // Service cards component with detailed information about each service
 const ServiceCards = () => (

--- a/app/work/[articleId]/page.js
+++ b/app/work/[articleId]/page.js
@@ -5,7 +5,6 @@ import Avatar from "../_assets/components/Avatar";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
 import { articles } from "@/app/work/articles";
-import ButtonGradient from "@/components/ui/ButtonGradient";
 import ButtonLead from "@/components/ui/ButtonLead";
 
 export async function generateMetadata(props) {

--- a/app/work/_assets/components/CardArticle.js
+++ b/app/work/_assets/components/CardArticle.js
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
 import BadgeCategory from "./BadgeCategory";
-import Avatar from "./Avatar";
 
 // This is the article card that appears in the home page, in the category page, and in the author's page
 const CardArticle = ({

--- a/app/work/_assets/components/MuxVideoSlider.js
+++ b/app/work/_assets/components/MuxVideoSlider.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import MuxVideoPlayer from "./MuxVideoPlayer";
 
 export default function MuxVideoSlider({ videos }) {

--- a/app/work/articles/building-temptations.js
+++ b/app/work/articles/building-temptations.js
@@ -21,7 +21,7 @@ export const buildingTemptations = {
     urlRelative: "/work/temptations/temptations-banner.jpeg",
     alt: "Temptations cat treats",
   },
-  content: ({ openModal }) => (
+  content: () => (
     <>
       <Image
         src={introducingTemptations}

--- a/app/work/articles/gmb-praxis-app.js
+++ b/app/work/articles/gmb-praxis-app.js
@@ -1,11 +1,8 @@
 import Image from "next/image";
-import MuxPlayer from "@mux/mux-player-react";
 import praxis from "@/public/work/praxis/elements_macbook_iphone.webp";
 import praxisSuccess from "@/public/work/praxis/praxis-success.png";
 import { categories, authors } from '../_assets/content';
 import { styles } from '../_assets/styles';
-import ButtonGradient from "@/components/ui/ButtonGradient";
-import ButtonLead from "@/components/ui/ButtonLead";
 import MuxVideoPlayer from "../_assets/components/MuxVideoPlayer";
 
 export const gmbPraxisApp = {

--- a/app/work/author/[authorId]/page.js
+++ b/app/work/author/[authorId]/page.js
@@ -1,5 +1,6 @@
 import Image from "next/image";
-import { authors, articles } from "../../_assets/content";
+import { authors } from "../../_assets/content";
+import { articles } from "../../articles";
 import CardArticle from "../../_assets/components/CardArticle";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";

--- a/app/work/category/[categoryId]/page.js
+++ b/app/work/category/[categoryId]/page.js
@@ -1,4 +1,5 @@
-import { categories, articles } from "../../_assets/content";
+import { categories } from "../../_assets/content";
+import { articles } from "../../articles";
 import CardArticle from "../../_assets/components/CardArticle";
 import CardCategory from "../../_assets/components/CardCategory";
 import { getSEOTags } from "@/libs/seo";

--- a/components/marketing/Pricing.js
+++ b/components/marketing/Pricing.js
@@ -1,5 +1,4 @@
 import config from "@/config";
-import ButtonGradient from "../ui/ButtonGradient";
 import ButtonLead from "../ui/ButtonLead";
 import ButtonCheckout from "../ui/ButtonCheckout";
 


### PR DESCRIPTION
- Fix articles import in author/[authorId] and category/[categoryId] pages by importing from correct module (../../articles instead of ../../_assets/content)
- Remove unused imports across multiple files:
  - stripe/create-checkout: getServerSession, authOptions, connectMongo, User
  - services/page: UkraineCallOut
  - [articleId]/page: ButtonGradient
  - CardArticle: Avatar
  - MuxVideoSlider: useEffect
  - building-temptations: openModal parameter
  - gmb-praxis-app: MuxPlayer, ButtonGradient, ButtonLead
  - Pricing: ButtonGradient