### PR TITLE
feat: add headline A/B testing with headline-goat

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -29,6 +29,8 @@ export default function RootLayout({ children }) {
           <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
           <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
           <meta name="theme-color" content={config.colors.main} />
+          {/* Headline A/B Testing - https://github.com/gkobilansky/headline-goat */}
+          <script src="https://nan-finder.exe.xyz/hlg.js" defer></script>
         </head>
       )}
       <body>

--- a/components/marketing/Hero.js
+++ b/components/marketing/Hero.js
@@ -16,13 +16,16 @@ const Hero = () => {
         <h1 className="font-extrabold text-4xl lg:text-5xl md:-mb-4 brightness-150 contrast-150">
           <span className="bg-clip-text text-5xl lg:text-6xl uppercase text-transparent tracking-tight leading-relaxed bg-[length:100%_100%] bg-gradient-to-tr from-[#0066CC] to-[#FFCC00]">Web tech</span>
           <br />
-          <span>that moves the needle.</span>
+          <span
+            data-hlg-name="hero-tagline"
+            data-hlg-variants='["that moves the needle.", "that helps you ship faster.", "that scales with you."]'
+          >that moves the needle.</span>
         </h1>
         <p className="text-lg opacity-80 leading-relaxed">
         You're small but <strong>mighty, and ready to grow</strong> — you just need the right tech to do it. We can build that for you. <em>Fast.</em><br/>
         <a href="#intro" className="link link-hover" onClick={(e) => {
             goToIntro(e);
-          }}><span className="bg-warning/25 px-1.5 leading-10">↓ Let's get started</span></a>
+          }} data-hlg-convert="hero-tagline"><span className="bg-warning/25 px-1.5 leading-10">↓ Let's get started</span></a>
         </p>
 
         <div className="lg:hidden w-full">


### PR DESCRIPTION
## Summary
- Integrate [headline-goat](https://github.com/gkobilansky/headline-goat) for A/B testing
- Test three tagline variants on the hero section
- Track conversions on "Let's get started" CTA click

## Headline Variants Being Tested
1. "that moves the needle." (control)
2. "that helps you ship faster."
3. "that scales with you."

## How It Works
- The hlg.js script is loaded from `https://nan-finder.exe.xyz/hlg.js` (headline-goat server running on exe.dev VPS)
- Visitors are randomly assigned a variant which persists via localStorage
- Clicking "Let's get started" registers a conversion for that visitor

## Monitoring Results
```bash
# SSH into the VPS and run:
cd ~/headline-goat && ./hlg results hero-tagline
```

## Test plan
- [ ] Verify hlg.js loads without errors
- [ ] Confirm headline variants rotate for different visitors
- [ ] Check that conversions are tracked when clicking CTA
- [ ] Monitor results via `hlg results hero-tagline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)