### PR TITLE
fix: prevent headline flash during A/B test swap

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,11 @@ body {
   scroll-behavior: smooth !important;
 }
 
+/* Hide A/B test elements until hlg.js swaps the content (prevents flash) */
+[data-hlg-name] {
+  visibility: hidden;
+}
+
 /* It makes the HTML progress bar filling smooth when value change. */
 progress::-webkit-progress-value {
   transition: 0.6s width ease-out;


### PR DESCRIPTION
## Summary
- Add CSS rule to hide `[data-hlg-name]` elements until hlg.js swaps the content

## How it works
1. CSS hides elements with `data-hlg-name` attribute on page load
2. headline-goat's hlg.js swaps in the variant text
3. hlg.js sets `visibility: visible` after swap

This prevents the flash of the original headline before the A/B variant loads.

**Requires:** headline-goat PR #5 (adds visibility handling to hlg.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)