### PR TITLE
feat: add 5 homepage redesign concepts for review

### DIFF
--- a/app/concepts/1/page.js
+++ b/app/concepts/1/page.js
@@ -1,0 +1,541 @@
+"use client";
+
+import { Suspense, useState, useRef } from "react";
+import Image from "next/image";
+import { motion, useInView, useScroll, useTransform } from "framer-motion";
+import config from "@/config";
+import Header from "@/components/layout/Header";
+import Modal from "@/components/marketing/Modal";
+import ButtonLead from "@/components/ui/ButtonLead";
+import ButtonCheckout from "@/components/ui/ButtonCheckout";
+import Footer from "@/components/layout/Footer";
+
+/*
+ * CONCEPT 1: "Bold Split-Screen"
+ *
+ * Design philosophy: Asymmetric layouts, dramatic split-screen sections,
+ * oversized typography, and bold color blocking. Each section uses a
+ * split layout with content on one side and a visual element on the other.
+ * Inspired by high-end agency sites like Huge Inc, Rally, and Collins.
+ */
+
+const testimonials = [
+  { rating: 5, text: "Gene isn't just a coder - he understands that code has to ship and ultimately drive business results. He's creative, human, and has accommodated a lot of weird ideas for us over the years, usually making them better in the execution.", author: "Andy F", authorTitle: "GMB Fitness Founder", authorImage: "/testimonials/andy.jpeg" },
+  { rating: 5, text: "Your UX is great! Best onboarding I've seen in any course period.", author: "Omar Z", authorTitle: "Praxis User, Founder of $100 MBA podcast", authorImage: "/testimonials/omar-zenhom.jpeg" },
+  { rating: 5, text: "Since the new site went live, we've received nothing but positive feedback from the teachers and coaches who use it", author: "Katy W", authorTitle: "Program Director, The Art of Learning Foundation", authorImage: "/testimonials/katy-wells.jpeg" },
+  { rating: 5, text: "I also have to mention the Praxis platform (build by Lansky) - it's the best in the business!.", author: "Mark", authorTitle: "Praxis User", authorImage: "/testimonials/lion.jpeg" },
+  { rating: 5, text: "A consummate professional with exceptional patience Gene worked tirelessly to deliver the work I wanted.", author: "Shawn S", authorTitle: "iLiveFit Founder, USAF Captain", authorImage: "/testimonials/shawn-swift.jpeg" },
+];
+
+const faqList = [
+  { question: "What types of web applications do you specialize in building?", answer: "We specialize in high-performance web applications, custom e-commerce solutions, and conversion-focused marketing sites." },
+  { question: "What's the difference between a web application and a website?", answer: "A website primarily delivers information. A web application is interactive software that lets users perform complex tasks, manipulate data, and create content in real-time." },
+  { question: "How can I sell more online?", answer: "High-converting checkout pages, mobile-first design, smart upsell systems, subscription options, performance optimization, and analytics integration." },
+  { question: "Can you build an app that does X?", answer: "Anything can be built. Our goal is to find the leanest version of your product. That's the hard part." },
+  { question: "How do you measure success?", answer: "Through concrete business outcomes: conversion rates, user engagement, retention metrics, lead generation, and performance benchmarks." },
+  { question: "I have another question", answer: "Contact us at hi@lansky.tech" },
+];
+
+// ─── HERO: Full-viewport split screen ─────────────────────────────
+function HeroBold() {
+  return (
+    <section className="min-h-screen flex flex-col lg:flex-row">
+      {/* Left panel - dark with text */}
+      <div className="lg:w-1/2 bg-neutral flex items-center justify-center px-8 py-24 lg:py-0 relative overflow-hidden">
+        <div className="absolute inset-0 opacity-5">
+          <div className="absolute top-20 left-10 w-72 h-72 rounded-full bg-primary blur-3xl" />
+          <div className="absolute bottom-20 right-10 w-96 h-96 rounded-full bg-secondary blur-3xl" />
+        </div>
+        <div className="relative z-10 max-w-lg">
+          <motion.div
+            initial={{ opacity: 0, x: -40 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.8 }}
+          >
+            <p className="text-primary font-mono text-sm tracking-widest uppercase mb-6">Lansky Tech</p>
+            <h1 className="text-5xl md:text-7xl font-black text-neutral-content leading-[0.95] tracking-tight mb-8">
+              Web tech
+              <br />
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+                that moves
+              </span>
+              <br />
+              the needle.
+            </h1>
+            <p className="text-neutral-content/70 text-lg leading-relaxed mb-10 max-w-md">
+              You&apos;re small but <strong className="text-neutral-content">mighty, and ready to grow</strong> — you just need the right tech to do it. We can build that for you. <em>Fast.</em>
+            </p>
+            <a
+              href="#problem-bold"
+              className="group inline-flex items-center gap-3 text-primary font-semibold text-lg hover:gap-5 transition-all"
+            >
+              See how we do it
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+            </a>
+          </motion.div>
+        </div>
+      </div>
+
+      {/* Right panel - image/visual */}
+      <div className="lg:w-1/2 bg-base-200 flex items-center justify-center p-8 lg:p-16 relative">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.8, delay: 0.3 }}
+          className="relative w-full max-w-xl"
+        >
+          <Image
+            src="/lansky-solutions.png"
+            alt="Lansky Solutions"
+            width={7041}
+            height={5788}
+            className="w-full h-auto"
+            priority
+          />
+          {/* Floating stat cards */}
+          <motion.div
+            className="absolute -bottom-4 -left-4 bg-base-100 rounded-xl shadow-2xl p-4 border border-base-300"
+            animate={{ y: [0, -8, 0] }}
+            transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+          >
+            <p className="text-3xl font-black text-primary">5+</p>
+            <p className="text-xs text-base-content/60">Years with clients</p>
+          </motion.div>
+          <motion.div
+            className="absolute -top-4 -right-4 bg-base-100 rounded-xl shadow-2xl p-4 border border-base-300"
+            animate={{ y: [0, -8, 0] }}
+            transition={{ duration: 3, repeat: Infinity, ease: "easeInOut", delay: 1 }}
+          >
+            <p className="text-3xl font-black text-secondary">100%</p>
+            <p className="text-xs text-base-content/60">5-star reviews</p>
+          </motion.div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+// ─── LOGO BAR ─────────────────────────────────────────────────────
+function LogoBar() {
+  const logos = ["Samsung", "Amazon", "GE", "GMB", "Touchtunes"];
+  return (
+    <div className="bg-base-100 border-y border-base-300 py-8 overflow-hidden">
+      <div className="max-w-7xl mx-auto px-8 flex items-center justify-between gap-12 opacity-40">
+        {logos.map((name) => (
+          <span key={name} className="text-sm font-semibold tracking-widest uppercase whitespace-nowrap">{name}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── PROBLEM: Reversed split-screen ───────────────────────────────
+function ProblemBold() {
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, margin: "-100px" });
+
+  return (
+    <section id="problem-bold" className="min-h-screen flex flex-col-reverse lg:flex-row" ref={ref}>
+      {/* Left: Visual/data */}
+      <div className="lg:w-1/2 bg-base-200 flex items-center justify-center p-8 lg:p-16">
+        <div className="max-w-md w-full">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={isInView ? { opacity: 1 } : {}}
+            transition={{ duration: 0.6 }}
+            className="space-y-6"
+          >
+            {/* Failure flow */}
+            {[
+              { emoji: "💡", label: "Beautiful new idea", color: "bg-success/20 border-success/30" },
+              { emoji: "👩🏻‍💻", label: "Design tons of features", color: "bg-info/20 border-info/30" },
+              { emoji: "💰", label: "Project overruns", color: "bg-warning/20 border-warning/30" },
+              { emoji: "😤", label: "Project fails", color: "bg-error/20 border-error/30" },
+            ].map((step, i) => (
+              <motion.div
+                key={step.label}
+                initial={{ opacity: 0, x: -30 }}
+                animate={isInView ? { opacity: 1, x: 0 } : {}}
+                transition={{ duration: 0.4, delay: i * 0.15 }}
+                className={`flex items-center gap-4 p-4 rounded-xl border ${step.color}`}
+              >
+                <span className="text-3xl">{step.emoji}</span>
+                <div>
+                  <p className="font-bold">{step.label}</p>
+                  {i < 3 && <p className="text-xs text-base-content/50 mt-1">leads to...</p>}
+                </div>
+                {i < 3 && (
+                  <svg className="w-5 h-5 ml-auto text-base-content/30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                  </svg>
+                )}
+              </motion.div>
+            ))}
+          </motion.div>
+        </div>
+      </div>
+
+      {/* Right: Text content */}
+      <div className="lg:w-1/2 bg-neutral flex items-center justify-center px-8 py-24 lg:py-0">
+        <div className="max-w-lg">
+          <p className="text-error font-mono text-sm tracking-widest uppercase mb-6">The problem</p>
+          <h2 className="text-4xl md:text-6xl font-black text-neutral-content leading-tight tracking-tight mb-8">
+            70% of tech projects fail
+          </h2>
+          <p className="text-neutral-content/70 text-lg leading-relaxed mb-8">
+            Not finding a <em>good enough</em> solution, too much complexity, ignoring users... There&apos;s so many ways good ideas can lose steam.
+          </p>
+          <div className="space-y-3 text-neutral-content/60">
+            {[
+              "Developers focus on the task, not the full picture",
+              "They don't understand your business goals",
+              "Complexity = more billable hours",
+              "User experience is an afterthought",
+              "Tech jargon instead of clear communication",
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3">
+                <span className="text-primary mt-1">&#x2192;</span>
+                <span>{item}</span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-8 text-neutral-content font-bold text-lg">
+            You need development designed for growth.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── SERVICES: Stacked cards ──────────────────────────────────────
+function ServicesBold() {
+  const services = [
+    { icon: "📺", title: "Web Apps", description: "Get a custom-built, high-performance web application that's lean, profitable, and designed to grow with you." },
+    { icon: "💳", title: "Ecommerce", description: "Create seamless and effective e-commerce flows that take users from discovery to checkout in a fully integrated funnel." },
+    { icon: "🎨", title: "Marketing Sites", description: "Convert visitors into customers with fast-loading landing pages, immersive product showcases, and easy content management." },
+  ];
+
+  return (
+    <section className="py-24 md:py-32 bg-base-100" id="solutions-bold">
+      <div className="max-w-7xl mx-auto px-8">
+        <div className="flex flex-col lg:flex-row gap-16 lg:gap-24">
+          {/* Left: sticky heading */}
+          <div className="lg:w-1/3 lg:sticky lg:top-32 lg:self-start">
+            <p className="text-primary font-mono text-sm tracking-widest uppercase mb-4">What we do</p>
+            <h2 className="text-4xl md:text-5xl font-black tracking-tight leading-tight mb-6">
+              We start small & iterate to build a lean, profitable product
+            </h2>
+            <p className="text-base-content/60 text-lg">
+              We specialize in three core areas that drive real business results.
+            </p>
+          </div>
+
+          {/* Right: service cards */}
+          <div className="lg:w-2/3 space-y-8">
+            {services.map((service, i) => (
+              <motion.div
+                key={service.title}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, margin: "-80px" }}
+                transition={{ duration: 0.5, delay: i * 0.1 }}
+                className="group relative bg-base-200 rounded-2xl p-8 md:p-12 border border-base-300 hover:border-primary/30 transition-colors"
+              >
+                <div className="flex items-start gap-6">
+                  <span className="text-5xl">{service.icon}</span>
+                  <div>
+                    <h3 className="text-2xl font-bold mb-3 group-hover:text-primary transition-colors">{service.title}</h3>
+                    <p className="text-base-content/70 text-lg leading-relaxed">{service.description}</p>
+                  </div>
+                </div>
+                <div className="absolute top-8 right-8 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <svg className="w-6 h-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                  </svg>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TESTIMONIALS: Marquee strip ──────────────────────────────────
+function TestimonialsBold() {
+  return (
+    <section className="py-24 bg-neutral overflow-hidden">
+      <div className="max-w-7xl mx-auto px-8 mb-16">
+        <h2 className="text-4xl md:text-5xl font-black text-neutral-content tracking-tight">
+          What people say about
+          <br />
+          <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">working with us</span>
+        </h2>
+      </div>
+      <div className="flex gap-6 animate-[scroll_30s_linear_infinite]" style={{ width: "max-content" }}>
+        {[...testimonials, ...testimonials].map((t, i) => (
+          <div key={i} className="w-80 shrink-0 bg-base-100/5 border border-neutral-content/10 rounded-xl p-6 backdrop-blur-sm">
+            <div className="flex mb-3">
+              {[...Array(t.rating)].map((_, j) => (
+                <svg key={j} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 text-warning">
+                  <path fillRule="evenodd" d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z" clipRule="evenodd" />
+                </svg>
+              ))}
+            </div>
+            <p className="text-neutral-content/80 text-sm leading-relaxed mb-4">&ldquo;{t.text}&rdquo;</p>
+            <div className="flex items-center gap-3">
+              <Image src={t.authorImage} alt={t.author} width={32} height={32} className="rounded-full" />
+              <div>
+                <p className="text-neutral-content font-medium text-sm">{t.author}</p>
+                <p className="text-neutral-content/50 text-xs">{t.authorTitle}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── FOUNDER: Large portrait split ────────────────────────────────
+function FounderBold({ openModal }) {
+  return (
+    <section className="min-h-screen flex flex-col lg:flex-row" id="hello-bold">
+      <div className="lg:w-2/5 bg-gradient-to-br from-[#0066CC] to-[#004499] flex items-center justify-center p-12 lg:p-16">
+        <div className="text-center">
+          <Image
+            src="/gene-kobilansky-headshot-yellow-bg.png"
+            alt="Gene Kobilansky"
+            width={250}
+            height={250}
+            className="rounded-full mx-auto mb-8 ring-4 ring-white/20"
+          />
+          <Image
+            src="/gk-initials-white.png"
+            alt="Gene Kobilansky signature"
+            width={1920}
+            height={1080}
+            className="max-w-40 mx-auto opacity-80"
+          />
+        </div>
+      </div>
+      <div className="lg:w-3/5 bg-base-100 flex items-center justify-center px-8 py-24 lg:py-0">
+        <div className="max-w-xl">
+          <p className="text-primary font-mono text-sm tracking-widest uppercase mb-6">Hello</p>
+          <h2 className="text-4xl md:text-5xl font-black tracking-tight leading-tight mb-8">
+            What if web development could be <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">faster, easier, and simpler?</span>
+          </h2>
+          <div className="space-y-4 text-base-content/70 text-lg leading-relaxed">
+            <p>Hi, I&apos;m Gene Kobilansky, founder of Lansky Tech, and that is <strong className="text-base-content">exactly my specialty</strong>.</p>
+            <p>I&apos;ve worked with companies of all sizes — from small charity organizations just getting off the ground, to some of the biggest companies in the world, like McDonald&apos;s, Amazon, GE, and Samsung.</p>
+            <p>They all needed the right tech solutions to help them grow, with as little tech bloat as possible.</p>
+            <p className="font-medium text-base-content">I look forward to hearing from you.</p>
+          </div>
+          <div className="mt-8">
+            <ButtonLead />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── PRICING: Bold cards with border accent ───────────────────────
+function PricingBold({ openModal }) {
+  return (
+    <section className="py-24 md:py-32 bg-base-200" id="prices-bold">
+      <div className="max-w-6xl mx-auto px-8">
+        <div className="text-center mb-16">
+          <p className="text-primary font-mono text-sm tracking-widest uppercase mb-4">Pricing</p>
+          <h2 className="text-4xl md:text-6xl font-black tracking-tight mb-4">
+            Simple Pricing to Get Started
+          </h2>
+          <p className="text-base-content/60 text-lg max-w-2xl mx-auto">
+            We&apos;re transparent about our pricing and we&apos;re not interested in overhead.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          {config.stripe.plans.map((plan) => (
+            <div
+              key={plan.priceId}
+              className={`relative rounded-2xl bg-base-100 p-8 flex flex-col ${
+                plan.isFeatured ? "ring-2 ring-primary shadow-xl shadow-primary/10" : "border border-base-300"
+              }`}
+            >
+              {plan.isFeatured && (
+                <div className="absolute -top-3 left-8">
+                  <span className="bg-primary text-primary-content text-xs font-bold px-3 py-1 rounded-full">Most Popular</span>
+                </div>
+              )}
+              <h3 className="text-xl font-bold mb-2">{plan.name}</h3>
+              <p className="text-base-content/60 text-sm mb-6 flex-grow">{plan.description}</p>
+              <ul className="space-y-2 mb-8">
+                {plan.features.map((f, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm">
+                    <svg className="w-4 h-4 text-primary shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                    <span>{f.name}</span>
+                  </li>
+                ))}
+              </ul>
+              <ButtonCheckout priceId={plan.priceId} ctaButtonText={plan.ctaButtonText} openModal={openModal} />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-16 text-center">
+          <h3 className="font-bold text-2xl mb-3">Not the right fit?</h3>
+          <p className="text-base-content/60">
+            Need something more custom, or just want to talk strategy?{" "}
+            <button
+              className="text-primary font-semibold hover:underline"
+              onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+            >
+              Send me a note →
+            </button>{" "}
+            No commitment.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FAQ: Split layout ────────────────────────────────────────────
+function FAQBold() {
+  const [openIndex, setOpenIndex] = useState(null);
+  return (
+    <section className="py-24 md:py-32 bg-base-100" id="faq-bold">
+      <div className="max-w-7xl mx-auto px-8 flex flex-col lg:flex-row gap-16">
+        <div className="lg:w-1/3">
+          <p className="text-primary font-mono text-sm tracking-widest uppercase mb-4">FAQ</p>
+          <h2 className="text-4xl font-black tracking-tight">
+            Frequently Asked Questions
+          </h2>
+        </div>
+        <div className="lg:w-2/3">
+          {faqList.map((item, i) => (
+            <div key={i} className="border-b border-base-300">
+              <button
+                className="w-full py-6 flex items-center justify-between text-left text-lg font-semibold hover:text-primary transition-colors"
+                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+              >
+                {item.question}
+                <span className={`transition-transform ${openIndex === i ? "rotate-45" : ""}`}>+</span>
+              </button>
+              <div className={`overflow-hidden transition-all duration-300 ${openIndex === i ? "max-h-40 pb-6" : "max-h-0"}`}>
+                <p className="text-base-content/70">{item.answer}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TOOLS: Side-by-side cards ────────────────────────────────────
+function ToolsBold() {
+  const [url, setUrl] = useState("");
+  const handleTestPage = (e) => {
+    e.preventDefault();
+    let testUrl = url.trim();
+    if (!testUrl) return;
+    if (!/^https?:\/\//i.test(testUrl)) testUrl = `https://${testUrl}`;
+    window.open(`https://landingpage.report?url=${encodeURIComponent(testUrl)}`, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="py-24 md:py-32 bg-base-200">
+      <div className="max-w-6xl mx-auto px-8">
+        <p className="text-primary font-mono text-sm tracking-widest uppercase mb-4">Free Tools</p>
+        <h2 className="text-4xl md:text-5xl font-black tracking-tight mb-4">Tools to Help Your Business Grow</h2>
+        <p className="text-base-content/60 text-lg mb-12">We build tools that solve real problems. Try them free.</p>
+
+        <div className="grid md:grid-cols-2 gap-8">
+          <div className="bg-base-100 rounded-2xl p-8 border border-base-300 hover:border-primary/30 transition-colors">
+            <span className="text-4xl mb-4 block">🎯</span>
+            <h3 className="text-2xl font-bold mb-2">Landing Page Report</h3>
+            <p className="text-base-content/60 mb-6">Get instant AI-powered feedback on your landing page&apos;s effectiveness.</p>
+            <form onSubmit={handleTestPage} className="space-y-3">
+              <input type="url" placeholder="https://your-landing-page.com" value={url} onChange={(e) => setUrl(e.target.value)} className="input input-bordered w-full" required />
+              <button type="submit" className="btn btn-primary w-full">Analyze Your Page</button>
+            </form>
+          </div>
+          <div className="bg-base-100 rounded-2xl p-8 border border-base-300 hover:border-primary/30 transition-colors">
+            <span className="text-4xl mb-4 block">🚀</span>
+            <h3 className="text-2xl font-bold mb-2">Compute Prices</h3>
+            <p className="text-base-content/60 mb-6">Compare GPU prices across 27+ providers instantly.</p>
+            <div className="flex flex-wrap gap-2 mb-6">
+              {["H100", "A100", "RTX 4090", "L40S", "+20 more"].map((g) => (
+                <span key={g} className="badge badge-outline">{g}</span>
+              ))}
+            </div>
+            <a href="https://computeprices.com" target="_blank" rel="noopener noreferrer" className="btn btn-primary w-full">
+              Compare GPU Prices
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── CTA: Full-width bold ─────────────────────────────────────────
+function CTABold({ openModal }) {
+  return (
+    <section className="py-24 bg-neutral text-center">
+      <div className="max-w-3xl mx-auto px-8">
+        <h2 className="text-4xl md:text-6xl font-black text-neutral-content tracking-tight mb-6">
+          Ready to build something great?
+        </h2>
+        <p className="text-neutral-content/60 text-lg mb-10">
+          Let&apos;s talk about your project. No strings attached.
+        </p>
+        <button
+          className="btn btn-primary btn-lg"
+          onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+        >
+          Get in touch
+        </button>
+      </div>
+    </section>
+  );
+}
+
+// ─── MAIN PAGE ────────────────────────────────────────────────────
+export default function Concept1() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalContent, setModalContent] = useState(null);
+  const [modalTitle, setModalTitle] = useState("");
+
+  const openModal = (content, title) => {
+    setModalContent(content);
+    setModalTitle(title || "");
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Suspense><Header openModal={openModal} /></Suspense>
+      <main>
+        <HeroBold />
+        <LogoBar />
+        <ToolsBold />
+        <ProblemBold />
+        <ServicesBold />
+        <TestimonialsBold />
+        <FounderBold openModal={openModal} />
+        <PricingBold openModal={openModal} />
+        <FAQBold />
+        <CTABold openModal={openModal} />
+        <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} title={modalTitle}>
+          {modalContent}
+        </Modal>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/concepts/2/page.js
+++ b/app/concepts/2/page.js
@@ -1,0 +1,515 @@
+"use client";
+
+import { Suspense, useState, useRef } from "react";
+import Image from "next/image";
+import { motion, useInView } from "framer-motion";
+import config from "@/config";
+import Header from "@/components/layout/Header";
+import Modal from "@/components/marketing/Modal";
+import ButtonLead from "@/components/ui/ButtonLead";
+import ButtonCheckout from "@/components/ui/ButtonCheckout";
+import Footer from "@/components/layout/Footer";
+
+/*
+ * CONCEPT 2: "Minimalist Editorial"
+ *
+ * Design philosophy: Clean whitespace, oversized serif-style headings,
+ * single-column centered layout, muted palette with one accent.
+ * Inspired by Apple's marketing pages, Stripe, and editorial magazines.
+ * Content breathes — generous padding, no visual clutter.
+ */
+
+const testimonials = [
+  { rating: 5, text: "Gene isn't just a coder - he understands that code has to ship and ultimately drive business results. He's creative, human, and has accommodated a lot of weird ideas for us over the years, usually making them better in the execution.", author: "Andy F", authorTitle: "GMB Fitness Founder", authorImage: "/testimonials/andy.jpeg" },
+  { rating: 5, text: "Your UX is great! Best onboarding I've seen in any course period.", author: "Omar Z", authorTitle: "Praxis User, Founder of $100 MBA podcast", authorImage: "/testimonials/omar-zenhom.jpeg" },
+  { rating: 5, text: "Since the new site went live, we've received nothing but positive feedback from the teachers and coaches who use it", author: "Katy W", authorTitle: "Program Director, The Art of Learning Foundation", authorImage: "/testimonials/katy-wells.jpeg" },
+  { rating: 5, text: "I also have to mention the Praxis platform (build by Lansky) - it's the best in the business!.", author: "Mark", authorTitle: "Praxis User", authorImage: "/testimonials/lion.jpeg" },
+  { rating: 5, text: "A consummate professional with exceptional patience Gene worked tirelessly to deliver the work I wanted.", author: "Shawn S", authorTitle: "iLiveFit Founder, USAF Captain", authorImage: "/testimonials/shawn-swift.jpeg" },
+];
+
+const faqList = [
+  { question: "What types of web applications do you specialize in building?", answer: "We specialize in high-performance web applications, custom e-commerce solutions, and conversion-focused marketing sites." },
+  { question: "What's the difference between a web application and a website?", answer: "A website primarily delivers information. A web application is interactive software that lets users perform complex tasks, manipulate data, and create content in real-time." },
+  { question: "How can I sell more online?", answer: "High-converting checkout pages, mobile-first design, smart upsell systems, subscription options, performance optimization, and analytics integration." },
+  { question: "Can you build an app that does X?", answer: "Anything can be built. Our goal is to find the leanest version of your product. That's the hard part." },
+  { question: "How do you measure success?", answer: "Through concrete business outcomes: conversion rates, user engagement, retention metrics, lead generation, and performance benchmarks." },
+  { question: "I have another question", answer: "Contact us at hi@lansky.tech" },
+];
+
+// ─── HERO: Centered, typographic ──────────────────────────────────
+function HeroEditorial() {
+  return (
+    <section className="min-h-screen flex items-center justify-center relative px-8">
+      <div className="absolute inset-0 bg-gradient-to-b from-base-100 via-base-100 to-base-200 pointer-events-none" />
+      <div className="relative z-10 text-center max-w-4xl mx-auto py-32 lg:py-48">
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 1, ease: "easeOut" }}
+        >
+          <p className="text-primary text-sm tracking-[0.3em] uppercase font-medium mb-8">Lansky Tech</p>
+          <h1 className="text-6xl md:text-8xl lg:text-9xl font-extralight tracking-tight leading-[0.9] mb-8">
+            Web tech
+            <br />
+            <span className="font-black bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+              that moves
+            </span>
+            <br />
+            the needle.
+          </h1>
+          <p className="text-base-content/50 text-xl md:text-2xl max-w-xl mx-auto leading-relaxed mt-12">
+            You&apos;re small but mighty, and ready to grow — you just need the right tech to do it.
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.8, duration: 0.6 }}
+          className="mt-16"
+        >
+          <a
+            href="#problem-editorial"
+            className="inline-flex items-center gap-2 text-base-content/40 hover:text-primary transition-colors text-sm tracking-widest uppercase"
+          >
+            <span>Scroll to explore</span>
+            <motion.svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              animate={{ y: [0, 4, 0] }}
+              transition={{ duration: 2, repeat: Infinity }}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 14l-7 7m0 0l-7-7" />
+            </motion.svg>
+          </a>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+// ─── STAT: Large number + text ────────────────────────────────────
+function StatLine() {
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true });
+
+  return (
+    <section className="py-20 border-y border-base-300" ref={ref}>
+      <div className="max-w-5xl mx-auto px-8 flex flex-col md:flex-row items-center justify-center gap-12 md:gap-24">
+        {[
+          { number: "70%", label: "of tech projects fail" },
+          { number: "5+", label: "years with our clients" },
+          { number: "100%", label: "five-star reviews" },
+        ].map((stat, i) => (
+          <motion.div
+            key={stat.label}
+            initial={{ opacity: 0, y: 20 }}
+            animate={isInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.5, delay: i * 0.15 }}
+            className="text-center"
+          >
+            <p className="text-6xl md:text-7xl font-extralight tracking-tight text-primary">{stat.number}</p>
+            <p className="text-base-content/40 text-sm tracking-widest uppercase mt-2">{stat.label}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── PROBLEM: Long-form editorial ─────────────────────────────────
+function ProblemEditorial() {
+  return (
+    <section id="problem-editorial" className="py-24 md:py-40">
+      <div className="max-w-2xl mx-auto px-8">
+        <motion.div
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.8 }}
+        >
+          <p className="text-primary text-sm tracking-[0.3em] uppercase font-medium mb-12">The Problem</p>
+          <h2 className="text-4xl md:text-5xl font-extralight tracking-tight leading-tight mb-12">
+            70% of technology projects fail because they solve the <em className="font-medium not-italic text-primary">wrong problem</em>
+          </h2>
+          <div className="text-base-content/60 text-lg leading-[1.8] space-y-6">
+            <p>Not finding a good enough solution, too much complexity, ignoring users... There&apos;s so many ways good ideas can lose steam.</p>
+            <p>Here&apos;s where most businesses run into trouble when hiring developers:</p>
+          </div>
+
+          <div className="my-12 space-y-4">
+            {[
+              "The developers focus on the task in front of them, without looking at the full picture.",
+              "They don't understand the overall business goals.",
+              "They don't mind making things overly complicated — more billable hours.",
+              "They fail to account for user experience.",
+              "They're techies who just don't get how to communicate to non-techies.",
+            ].map((item, i) => (
+              <motion.div
+                key={i}
+                initial={{ opacity: 0, x: -10 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.08 }}
+                className="flex items-start gap-4 py-3 border-b border-base-300/50"
+              >
+                <span className="text-primary/40 font-light text-sm mt-0.5">{String(i + 1).padStart(2, "0")}</span>
+                <span className="text-base-content/70">{item}</span>
+              </motion.div>
+            ))}
+          </div>
+
+          <div className="mt-12 pl-6 border-l-2 border-primary/30">
+            <p className="text-lg text-base-content/60 leading-relaxed">
+              Projects that run over budget, over schedule, are prone to breaking, or worst case scenario: they never see the light of day.
+            </p>
+            <p className="text-xl font-medium text-base-content mt-4">
+              You need development designed for growth.
+            </p>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+// ─── SERVICES: Numbered list ──────────────────────────────────────
+function ServicesEditorial() {
+  const services = [
+    { num: "01", title: "Web Apps", description: "Get a custom-built, high-performance web application that's lean, profitable, and designed to grow with you." },
+    { num: "02", title: "Ecommerce", description: "Create seamless and effective e-commerce flows that take users from discovery to checkout in a fully integrated funnel." },
+    { num: "03", title: "Marketing Sites", description: "Convert visitors into customers with fast-loading landing pages, immersive product showcases, and easy content management." },
+  ];
+
+  return (
+    <section className="py-24 md:py-40 bg-base-200" id="solutions-editorial">
+      <div className="max-w-4xl mx-auto px-8">
+        <p className="text-primary text-sm tracking-[0.3em] uppercase font-medium mb-12">What we do</p>
+        <h2 className="text-4xl md:text-6xl font-extralight tracking-tight leading-tight mb-20">
+          We start small & iterate to build a lean, profitable product
+        </h2>
+
+        <div className="space-y-0">
+          {services.map((service, i) => (
+            <motion.div
+              key={service.title}
+              initial={{ opacity: 0 }}
+              whileInView={{ opacity: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="group py-12 border-t border-base-300 flex flex-col md:flex-row gap-6 md:gap-16"
+            >
+              <div className="md:w-16 shrink-0">
+                <span className="text-primary/30 text-sm font-light">{service.num}</span>
+              </div>
+              <div>
+                <h3 className="text-2xl md:text-3xl font-medium tracking-tight mb-4 group-hover:text-primary transition-colors">
+                  {service.title}
+                </h3>
+                <p className="text-base-content/50 text-lg leading-relaxed max-w-lg">{service.description}</p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TESTIMONIALS: Single featured + grid ─────────────────────────
+function TestimonialsEditorial() {
+  const featured = testimonials[0];
+  const rest = testimonials.slice(1);
+
+  return (
+    <section className="py-24 md:py-40">
+      <div className="max-w-4xl mx-auto px-8">
+        <p className="text-primary text-sm tracking-[0.3em] uppercase font-medium mb-12">Testimonials</p>
+
+        {/* Featured testimonial */}
+        <blockquote className="mb-20">
+          <p className="text-3xl md:text-4xl font-extralight leading-relaxed tracking-tight text-base-content/80">
+            &ldquo;{featured.text}&rdquo;
+          </p>
+          <div className="flex items-center gap-4 mt-8">
+            <Image src={featured.authorImage} alt={featured.author} width={48} height={48} className="rounded-full" />
+            <div>
+              <p className="font-medium">{featured.author}</p>
+              <p className="text-base-content/40 text-sm">{featured.authorTitle}</p>
+            </div>
+          </div>
+        </blockquote>
+
+        {/* Grid of others */}
+        <div className="grid md:grid-cols-2 gap-8 pt-12 border-t border-base-300">
+          {rest.map((t, i) => (
+            <div key={i} className="py-6">
+              <div className="flex mb-2">
+                {[...Array(t.rating)].map((_, j) => (
+                  <svg key={j} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 text-warning">
+                    <path fillRule="evenodd" d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z" clipRule="evenodd" />
+                  </svg>
+                ))}
+              </div>
+              <p className="text-base-content/60 text-sm leading-relaxed mb-3">&ldquo;{t.text}&rdquo;</p>
+              <div className="flex items-center gap-3">
+                <Image src={t.authorImage} alt={t.author} width={28} height={28} className="rounded-full" />
+                <div>
+                  <p className="text-sm font-medium">{t.author}</p>
+                  <p className="text-xs text-base-content/40">{t.authorTitle}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FOUNDER: Centered portrait ───────────────────────────────────
+function FounderEditorial() {
+  return (
+    <section className="py-24 md:py-40 bg-base-200" id="hello-editorial">
+      <div className="max-w-2xl mx-auto px-8 text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <Image
+            src="/gene-kobilansky-headshot-yellow-bg.png"
+            alt="Gene Kobilansky"
+            width={120}
+            height={120}
+            className="rounded-full mx-auto mb-8"
+          />
+          <h2 className="text-4xl md:text-5xl font-extralight tracking-tight mb-8">
+            What if web development could be{" "}
+            <span className="font-medium bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+              faster, easier, and simpler?
+            </span>
+          </h2>
+          <div className="text-base-content/50 text-lg leading-[1.8] space-y-6 text-left">
+            <p>Hi, I&apos;m Gene Kobilansky, founder of Lansky Tech, and that is <strong className="text-base-content">exactly my specialty</strong>.</p>
+            <p>I&apos;ve worked with companies of all sizes — from small charity organizations just getting off the ground, to some of the biggest companies in the world, like McDonald&apos;s, Amazon, GE, and Samsung.</p>
+            <p>They all needed the right tech solutions to help them grow, with as little tech bloat as possible.</p>
+          </div>
+          <div className="mt-8 flex justify-center">
+            <Image src="/gk-initials-white.png" alt="Gene Kobilansky signature" width={1920} height={1080} className="max-w-40 opacity-60" />
+          </div>
+          <div className="mt-8">
+            <ButtonLead />
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TOOLS: Minimal cards ─────────────────────────────────────────
+function ToolsEditorial() {
+  const [url, setUrl] = useState("");
+  const handleTestPage = (e) => {
+    e.preventDefault();
+    let testUrl = url.trim();
+    if (!testUrl) return;
+    if (!/^https?:\/\//i.test(testUrl)) testUrl = `https://${testUrl}`;
+    window.open(`https://landingpage.report?url=${encodeURIComponent(testUrl)}`, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="py-24 md:py-40">
+      <div className="max-w-4xl mx-auto px-8">
+        <p className="text-primary text-sm tracking-[0.3em] uppercase font-medium mb-12">Free Tools</p>
+        <h2 className="text-4xl md:text-5xl font-extralight tracking-tight mb-16">
+          Tools to Help Your Business Grow
+        </h2>
+
+        <div className="space-y-8">
+          <div className="p-8 md:p-12 border border-base-300 rounded-xl">
+            <div className="flex flex-col md:flex-row gap-8 md:gap-16">
+              <div className="md:w-1/2">
+                <h3 className="text-2xl font-medium mb-2">Landing Page Report</h3>
+                <p className="text-base-content/50 leading-relaxed">Get instant AI-powered feedback on your landing page&apos;s effectiveness. Analyze copy, design, and conversion potential.</p>
+              </div>
+              <div className="md:w-1/2">
+                <form onSubmit={handleTestPage} className="space-y-3">
+                  <input type="url" placeholder="https://your-landing-page.com" value={url} onChange={(e) => setUrl(e.target.value)} className="input input-bordered w-full bg-base-200/50" required />
+                  <button type="submit" className="btn btn-primary w-full">Analyze Your Page</button>
+                </form>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-8 md:p-12 border border-base-300 rounded-xl">
+            <div className="flex flex-col md:flex-row gap-8 md:gap-16 items-center">
+              <div className="md:w-1/2">
+                <h3 className="text-2xl font-medium mb-2">Compute Prices</h3>
+                <p className="text-base-content/50 leading-relaxed">Compare GPU prices across 27+ providers instantly. Find the cheapest H100, A100, RTX 4090 and more.</p>
+                <div className="flex flex-wrap gap-2 mt-4">
+                  {["H100", "A100", "RTX 4090", "L40S", "+20 more"].map((g) => (
+                    <span key={g} className="text-xs text-base-content/40 border border-base-300 px-2 py-1 rounded">{g}</span>
+                  ))}
+                </div>
+              </div>
+              <div className="md:w-1/2">
+                <a href="https://computeprices.com" target="_blank" rel="noopener noreferrer" className="btn btn-primary w-full">
+                  Compare GPU Prices
+                </a>
+                <p className="text-center text-xs text-base-content/40 mt-3">Daily pricing updates from 27+ providers</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── PRICING: Clean centered ──────────────────────────────────────
+function PricingEditorial({ openModal }) {
+  return (
+    <section className="py-24 md:py-40 bg-base-200" id="prices-editorial">
+      <div className="max-w-5xl mx-auto px-8">
+        <div className="text-center mb-20">
+          <p className="text-primary text-sm tracking-[0.3em] uppercase font-medium mb-8">Pricing</p>
+          <h2 className="text-4xl md:text-6xl font-extralight tracking-tight mb-6">
+            Simple Pricing to Get Started
+          </h2>
+          <p className="text-base-content/40 text-lg max-w-xl mx-auto">
+            Transparent pricing. No overhead. No surprises.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-0 border border-base-300 rounded-xl overflow-hidden">
+          {config.stripe.plans.map((plan, i) => (
+            <div
+              key={plan.priceId}
+              className={`p-8 flex flex-col ${
+                plan.isFeatured ? "bg-base-100 relative" : "bg-base-100/50"
+              } ${i < 2 ? "border-b md:border-b-0 md:border-r border-base-300" : ""}`}
+            >
+              {plan.isFeatured && (
+                <span className="absolute top-4 right-4 text-xs text-primary font-medium tracking-widest uppercase">Popular</span>
+              )}
+              <h3 className="text-lg font-medium mb-2">{plan.name}</h3>
+              <p className="text-base-content/40 text-sm mb-8 flex-grow">{plan.description}</p>
+              <ul className="space-y-2.5 mb-8">
+                {plan.features.map((f, j) => (
+                  <li key={j} className="text-sm text-base-content/60 flex items-start gap-2">
+                    <span className="text-primary/50 mt-0.5">&#x2713;</span>
+                    <span>{f.name}</span>
+                  </li>
+                ))}
+              </ul>
+              <ButtonCheckout priceId={plan.priceId} ctaButtonText={plan.ctaButtonText} openModal={openModal} />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-16 text-center">
+          <p className="text-base-content/40">
+            Need something custom?{" "}
+            <button
+              className="text-primary hover:underline"
+              onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+            >
+              Let&apos;s talk →
+            </button>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FAQ: Clean accordion ─────────────────────────────────────────
+function FAQEditorial() {
+  const [openIndex, setOpenIndex] = useState(null);
+  return (
+    <section className="py-24 md:py-40" id="faq-editorial">
+      <div className="max-w-2xl mx-auto px-8">
+        <p className="text-primary text-sm tracking-[0.3em] uppercase font-medium mb-12">FAQ</p>
+        <h2 className="text-4xl font-extralight tracking-tight mb-16">
+          Frequently Asked Questions
+        </h2>
+        {faqList.map((item, i) => (
+          <div key={i} className="border-t border-base-300/50">
+            <button
+              className="w-full py-6 flex items-center justify-between text-left text-base hover:text-primary transition-colors"
+              onClick={() => setOpenIndex(openIndex === i ? null : i)}
+            >
+              <span className="pr-4">{item.question}</span>
+              <svg className={`w-4 h-4 shrink-0 transition-transform ${openIndex === i ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            <div className={`overflow-hidden transition-all duration-300 ${openIndex === i ? "max-h-40 pb-6" : "max-h-0"}`}>
+              <p className="text-base-content/50 text-sm leading-relaxed">{item.answer}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── CTA: Simple centered ─────────────────────────────────────────
+function CTAEditorial({ openModal }) {
+  return (
+    <section className="py-32 md:py-48 bg-base-200">
+      <div className="max-w-2xl mx-auto px-8 text-center">
+        <h2 className="text-4xl md:text-6xl font-extralight tracking-tight mb-8">
+          Let&apos;s build something
+          <br />
+          <span className="font-medium">together.</span>
+        </h2>
+        <p className="text-base-content/40 text-lg mb-12">No strings attached. Just a conversation.</p>
+        <button
+          className="btn btn-primary btn-lg"
+          onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+        >
+          Start a conversation
+        </button>
+      </div>
+    </section>
+  );
+}
+
+// ─── MAIN PAGE ────────────────────────────────────────────────────
+export default function Concept2() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalContent, setModalContent] = useState(null);
+  const [modalTitle, setModalTitle] = useState("");
+
+  const openModal = (content, title) => {
+    setModalContent(content);
+    setModalTitle(title || "");
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Suspense><Header openModal={openModal} /></Suspense>
+      <main>
+        <HeroEditorial />
+        <StatLine />
+        <ProblemEditorial />
+        <FounderEditorial />
+        <ServicesEditorial />
+        <TestimonialsEditorial />
+        <ToolsEditorial />
+        <PricingEditorial openModal={openModal} />
+        <FAQEditorial />
+        <CTAEditorial openModal={openModal} />
+        <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} title={modalTitle}>
+          {modalContent}
+        </Modal>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/concepts/3/page.js
+++ b/app/concepts/3/page.js
@@ -1,0 +1,488 @@
+"use client";
+
+import { Suspense, useState, useRef } from "react";
+import Image from "next/image";
+import { motion, useInView } from "framer-motion";
+import config from "@/config";
+import Header from "@/components/layout/Header";
+import Modal from "@/components/marketing/Modal";
+import ButtonLead from "@/components/ui/ButtonLead";
+import ButtonCheckout from "@/components/ui/ButtonCheckout";
+import Footer from "@/components/layout/Footer";
+
+/*
+ * CONCEPT 3: "Bento Grid / Dashboard"
+ *
+ * Design philosophy: Everything is a card. Bento-box grid layouts
+ * with varying card sizes, rounded corners, subtle borders, and
+ * a cohesive "dashboard" feel. Inspired by the Linear, Vercel,
+ * and Apple's latest bento-style marketing pages.
+ */
+
+const testimonials = [
+  { rating: 5, text: "Gene isn't just a coder - he understands that code has to ship and ultimately drive business results. He's creative, human, and has accommodated a lot of weird ideas for us over the years, usually making them better in the execution.", author: "Andy F", authorTitle: "GMB Fitness Founder", authorImage: "/testimonials/andy.jpeg" },
+  { rating: 5, text: "Your UX is great! Best onboarding I've seen in any course period.", author: "Omar Z", authorTitle: "Praxis User, Founder of $100 MBA podcast", authorImage: "/testimonials/omar-zenhom.jpeg" },
+  { rating: 5, text: "Since the new site went live, we've received nothing but positive feedback from the teachers and coaches who use it", author: "Katy W", authorTitle: "Program Director, The Art of Learning Foundation", authorImage: "/testimonials/katy-wells.jpeg" },
+  { rating: 5, text: "I also have to mention the Praxis platform (build by Lansky) - it's the best in the business!.", author: "Mark", authorTitle: "Praxis User", authorImage: "/testimonials/lion.jpeg" },
+  { rating: 5, text: "A consummate professional with exceptional patience Gene worked tirelessly to deliver the work I wanted.", author: "Shawn S", authorTitle: "iLiveFit Founder, USAF Captain", authorImage: "/testimonials/shawn-swift.jpeg" },
+];
+
+const faqList = [
+  { question: "What types of web applications do you specialize in building?", answer: "We specialize in high-performance web applications, custom e-commerce solutions, and conversion-focused marketing sites." },
+  { question: "What's the difference between a web application and a website?", answer: "A website primarily delivers information. A web application is interactive software that lets users perform complex tasks, manipulate data, and create content in real-time." },
+  { question: "How can I sell more online?", answer: "High-converting checkout pages, mobile-first design, smart upsell systems, subscription options, performance optimization, and analytics integration." },
+  { question: "Can you build an app that does X?", answer: "Anything can be built. Our goal is to find the leanest version of your product. That's the hard part." },
+  { question: "How do you measure success?", answer: "Through concrete business outcomes: conversion rates, user engagement, retention metrics, lead generation, and performance benchmarks." },
+  { question: "I have another question", answer: "Contact us at hi@lansky.tech" },
+];
+
+const BentoCard = ({ children, className = "", delay = 0 }) => (
+  <motion.div
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true, margin: "-50px" }}
+    transition={{ duration: 0.5, delay }}
+    className={`rounded-2xl border border-base-300 bg-base-100 overflow-hidden ${className}`}
+  >
+    {children}
+  </motion.div>
+);
+
+// ─── HERO: Bento hero grid ────────────────────────────────────────
+function HeroBento() {
+  return (
+    <section className="pt-28 lg:pt-36 pb-8 px-4 md:px-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Main hero card - spans 2 cols */}
+          <BentoCard className="lg:col-span-2 p-8 md:p-12 bg-gradient-to-br from-neutral to-neutral/90" delay={0}>
+            <p className="text-primary text-xs tracking-widest uppercase font-medium mb-6">Lansky Tech</p>
+            <h1 className="text-4xl md:text-6xl font-black text-neutral-content leading-[0.95] tracking-tight mb-6">
+              Web tech
+              <br />
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+                that moves the needle.
+              </span>
+            </h1>
+            <p className="text-neutral-content/60 text-lg max-w-lg mb-8">
+              You&apos;re small but <strong className="text-neutral-content">mighty, and ready to grow</strong> — you just need the right tech to do it. We can build that for you. <em>Fast.</em>
+            </p>
+            <a href="#prices-bento" className="btn btn-primary">Get started</a>
+          </BentoCard>
+
+          {/* Image card */}
+          <BentoCard className="p-6 flex items-center justify-center bg-base-200" delay={0.1}>
+            <Image
+              src="/lansky-solutions.png"
+              alt="Lansky Solutions"
+              width={7041}
+              height={5788}
+              className="w-full h-auto"
+              priority
+            />
+          </BentoCard>
+
+          {/* Stats row */}
+          <BentoCard className="p-6 flex items-center justify-center" delay={0.2}>
+            <div className="text-center">
+              <p className="text-4xl font-black text-primary">70%</p>
+              <p className="text-base-content/40 text-sm mt-1">of tech projects fail</p>
+            </div>
+          </BentoCard>
+
+          <BentoCard className="p-6 flex items-center justify-center" delay={0.25}>
+            <div className="text-center">
+              <p className="text-4xl font-black text-secondary">100%</p>
+              <p className="text-base-content/40 text-sm mt-1">5-star reviews</p>
+            </div>
+          </BentoCard>
+
+          <BentoCard className="p-6 flex items-center justify-center" delay={0.3}>
+            <div className="text-center">
+              <p className="text-4xl font-black text-accent">5+</p>
+              <p className="text-base-content/40 text-sm mt-1">years with clients</p>
+            </div>
+          </BentoCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TOOLS: Bento tool cards ──────────────────────────────────────
+function ToolsBento() {
+  const [url, setUrl] = useState("");
+  const handleTestPage = (e) => {
+    e.preventDefault();
+    let testUrl = url.trim();
+    if (!testUrl) return;
+    if (!/^https?:\/\//i.test(testUrl)) testUrl = `https://${testUrl}`;
+    window.open(`https://landingpage.report?url=${encodeURIComponent(testUrl)}`, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="py-4 px-4 md:px-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Section header card */}
+          <BentoCard className="p-8 bg-base-200" delay={0}>
+            <span className="text-3xl mb-3 block">🛠️</span>
+            <h2 className="text-3xl font-bold tracking-tight mb-2">Free Tools</h2>
+            <p className="text-base-content/50">We build tools that solve real problems. Try them free.</p>
+          </BentoCard>
+
+          {/* Landing Page Report */}
+          <BentoCard className="p-8" delay={0.1}>
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-xl">🎯</div>
+              <h3 className="font-bold text-lg">Landing Page Report</h3>
+            </div>
+            <p className="text-base-content/50 text-sm mb-4">Get instant AI-powered feedback on your landing page&apos;s effectiveness.</p>
+            <form onSubmit={handleTestPage} className="space-y-2">
+              <input type="url" placeholder="https://your-page.com" value={url} onChange={(e) => setUrl(e.target.value)} className="input input-bordered input-sm w-full" required />
+              <button type="submit" className="btn btn-primary btn-sm w-full">Analyze</button>
+            </form>
+          </BentoCard>
+
+          {/* Compute Prices */}
+          <BentoCard className="p-8" delay={0.15}>
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-green-500 to-cyan-600 flex items-center justify-center text-xl">🚀</div>
+              <h3 className="font-bold text-lg">Compute Prices</h3>
+            </div>
+            <p className="text-base-content/50 text-sm mb-4">Compare GPU prices across 27+ providers instantly.</p>
+            <div className="flex flex-wrap gap-1.5 mb-4">
+              {["H100", "A100", "RTX 4090", "L40S"].map((g) => (
+                <span key={g} className="badge badge-sm badge-outline">{g}</span>
+              ))}
+            </div>
+            <a href="https://computeprices.com" target="_blank" rel="noopener noreferrer" className="btn btn-primary btn-sm w-full">Compare Prices</a>
+          </BentoCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── PROBLEM: Bento problem grid ──────────────────────────────────
+function ProblemBento() {
+  return (
+    <section className="py-4 px-4 md:px-8" id="problem-bento">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
+          {/* Main problem text - spans 2 */}
+          <BentoCard className="lg:col-span-2 p-8 md:p-12 bg-neutral" delay={0}>
+            <p className="text-error/80 text-xs tracking-widest uppercase font-medium mb-4">The Problem</p>
+            <h2 className="text-3xl md:text-4xl font-black text-neutral-content tracking-tight leading-tight mb-4">
+              70% of technology projects fail because they solve the wrong problem
+            </h2>
+            <p className="text-neutral-content/60 leading-relaxed">
+              Not finding a good enough solution, too much complexity, ignoring users... There&apos;s so many ways good ideas can lose steam.
+            </p>
+          </BentoCard>
+
+          {/* Failure flow steps */}
+          <div className="lg:col-span-2 grid grid-cols-2 gap-4">
+            {[
+              { emoji: "💡", label: "Beautiful new idea", bg: "bg-success/5 border-success/20" },
+              { emoji: "👩🏻‍💻", label: "Design tons of features", bg: "bg-info/5 border-info/20" },
+              { emoji: "💰", label: "Project overruns", bg: "bg-warning/5 border-warning/20" },
+              { emoji: "😤", label: "Project fails", bg: "bg-error/5 border-error/20" },
+            ].map((step, i) => (
+              <BentoCard key={step.label} className={`p-6 flex flex-col items-center justify-center text-center ${step.bg}`} delay={i * 0.08}>
+                <span className="text-4xl mb-2">{step.emoji}</span>
+                <p className="font-bold text-sm">{step.label}</p>
+              </BentoCard>
+            ))}
+          </div>
+
+          {/* Pain points - full width */}
+          <BentoCard className="lg:col-span-4 p-8 bg-base-200" delay={0.2}>
+            <div className="grid md:grid-cols-5 gap-4">
+              {[
+                { icon: "🎯", text: "Developers focus on the task, not the full picture" },
+                { icon: "📊", text: "They don't understand your business goals" },
+                { icon: "⏰", text: "Complexity = more billable hours" },
+                { icon: "👤", text: "User experience is an afterthought" },
+                { icon: "💬", text: "Tech jargon instead of clear communication" },
+              ].map((item) => (
+                <div key={item.text} className="flex flex-col items-center text-center p-4">
+                  <span className="text-2xl mb-2">{item.icon}</span>
+                  <p className="text-sm text-base-content/60">{item.text}</p>
+                </div>
+              ))}
+            </div>
+            <p className="text-center font-bold text-lg mt-6">You need development designed for growth.</p>
+          </BentoCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── SERVICES: Large bento cards ──────────────────────────────────
+function ServicesBento() {
+  return (
+    <section className="py-4 px-4 md:px-8" id="solutions-bento">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Section header */}
+          <BentoCard className="lg:col-span-3 p-8 md:p-12" delay={0}>
+            <p className="text-primary text-xs tracking-widest uppercase font-medium mb-3">What we do</p>
+            <h2 className="text-3xl md:text-5xl font-black tracking-tight">
+              We start small & iterate to build a{" "}
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">lean, profitable product</span>
+            </h2>
+          </BentoCard>
+
+          {/* Service cards */}
+          {[
+            { icon: "📺", title: "Web Apps", desc: "Get a custom-built, high-performance web application that's lean, profitable, and designed to grow with you.", gradient: "from-blue-500/10 to-purple-500/10" },
+            { icon: "💳", title: "Ecommerce", desc: "Create seamless and effective e-commerce flows that take users from discovery to checkout in a fully integrated funnel.", gradient: "from-green-500/10 to-emerald-500/10" },
+            { icon: "🎨", title: "Marketing Sites", desc: "Convert visitors into customers with fast-loading landing pages, immersive product showcases, and easy content management.", gradient: "from-orange-500/10 to-yellow-500/10" },
+          ].map((service, i) => (
+            <BentoCard key={service.title} className={`p-8 hover:shadow-lg transition-shadow bg-gradient-to-br ${service.gradient}`} delay={i * 0.1}>
+              <span className="text-5xl mb-6 block">{service.icon}</span>
+              <h3 className="text-2xl font-bold mb-3">{service.title}</h3>
+              <p className="text-base-content/60 leading-relaxed">{service.desc}</p>
+            </BentoCard>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TESTIMONIALS: Masonry bento ──────────────────────────────────
+function TestimonialsBento() {
+  return (
+    <section className="py-4 px-4 md:px-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {/* Header card */}
+          <BentoCard className="md:col-span-2 lg:col-span-3 p-8" delay={0}>
+            <h2 className="text-3xl font-bold">
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">
+                What people say about working with us
+              </span>
+            </h2>
+          </BentoCard>
+
+          {testimonials.map((t, i) => (
+            <BentoCard key={i} className={`p-6 ${i === 0 ? "md:row-span-2" : ""}`} delay={i * 0.08}>
+              <div className="flex mb-3">
+                {[...Array(t.rating)].map((_, j) => (
+                  <svg key={j} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5 text-warning">
+                    <path fillRule="evenodd" d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z" clipRule="evenodd" />
+                  </svg>
+                ))}
+              </div>
+              <p className={`text-base-content/70 leading-relaxed mb-4 ${i === 0 ? "text-lg" : "text-sm"}`}>
+                &ldquo;{t.text}&rdquo;
+              </p>
+              <div className="flex items-center gap-3 mt-auto">
+                <Image src={t.authorImage} alt={t.author} width={32} height={32} className="rounded-full" />
+                <div>
+                  <p className="font-medium text-sm">{t.author}</p>
+                  <p className="text-xs text-base-content/40">{t.authorTitle}</p>
+                </div>
+              </div>
+            </BentoCard>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FOUNDER: Profile card + bio ──────────────────────────────────
+function FounderBento() {
+  return (
+    <section className="py-4 px-4 md:px-8" id="hello-bento">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Profile card */}
+          <BentoCard className="p-8 bg-gradient-to-br from-[#0066CC]/10 to-[#FFCC00]/10 flex flex-col items-center text-center" delay={0}>
+            <Image
+              src="/gene-kobilansky-headshot-yellow-bg.png"
+              alt="Gene Kobilansky"
+              width={120}
+              height={120}
+              className="rounded-full mb-4"
+            />
+            <h3 className="text-xl font-bold">Gene Kobilansky</h3>
+            <p className="text-base-content/50 text-sm">Founder, Lansky Tech</p>
+            <Image src="/gk-initials-white.png" alt="Signature" width={1920} height={1080} className="max-w-24 opacity-50 mt-4" />
+          </BentoCard>
+
+          {/* Bio card */}
+          <BentoCard className="lg:col-span-2 p-8 md:p-12" delay={0.1}>
+            <p className="text-primary text-xs tracking-widest uppercase font-medium mb-4">Hello</p>
+            <h2 className="text-3xl md:text-4xl font-black tracking-tight mb-6">
+              What if web development could be{" "}
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+                faster, easier, and simpler?
+              </span>
+            </h2>
+            <div className="text-base-content/60 leading-relaxed space-y-4">
+              <p>Hi, I&apos;m Gene Kobilansky, founder of Lansky Tech, and that is <strong className="text-base-content">exactly my specialty</strong>.</p>
+              <p>I&apos;ve worked with companies of all sizes — from small charity organizations to McDonald&apos;s, Amazon, GE, and Samsung. They all needed the right tech solutions to help them grow, with as little tech bloat as possible.</p>
+            </div>
+            <div className="mt-6">
+              <ButtonLead />
+            </div>
+          </BentoCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── PRICING: Bento pricing grid ──────────────────────────────────
+function PricingBento({ openModal }) {
+  return (
+    <section className="py-4 px-4 md:px-8" id="prices-bento">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Header card */}
+          <BentoCard className="lg:col-span-3 p-8 md:p-12 bg-base-200 text-center" delay={0}>
+            <p className="text-primary text-xs tracking-widest uppercase font-medium mb-3">Pricing</p>
+            <h2 className="text-3xl md:text-5xl font-black tracking-tight mb-4">Simple Pricing to Get Started</h2>
+            <p className="text-base-content/50 max-w-xl mx-auto">Transparent pricing. No overhead. Grab one of our services or reach out for a chat.</p>
+          </BentoCard>
+
+          {/* Price cards */}
+          {config.stripe.plans.map((plan, i) => (
+            <BentoCard
+              key={plan.priceId}
+              className={`p-8 flex flex-col ${plan.isFeatured ? "ring-2 ring-primary bg-primary/5" : ""}`}
+              delay={i * 0.1}
+            >
+              {plan.isFeatured && (
+                <span className="bg-primary text-primary-content text-xs font-bold px-3 py-1 rounded-full self-start mb-4">Most Popular</span>
+              )}
+              <h3 className="text-lg font-bold mb-2">{plan.name}</h3>
+              <p className="text-base-content/50 text-sm mb-6 flex-grow">{plan.description}</p>
+              <ul className="space-y-2 mb-6">
+                {plan.features.map((f, j) => (
+                  <li key={j} className="text-sm text-base-content/60 flex items-start gap-2">
+                    <svg className="w-4 h-4 text-primary shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                    <span>{f.name}</span>
+                  </li>
+                ))}
+              </ul>
+              <ButtonCheckout priceId={plan.priceId} ctaButtonText={plan.ctaButtonText} openModal={openModal} />
+            </BentoCard>
+          ))}
+
+          {/* CTA card */}
+          <BentoCard className="lg:col-span-3 p-8 text-center bg-base-200" delay={0.3}>
+            <p className="text-base-content/50">
+              Not the right fit? Need something custom?{" "}
+              <button
+                className="text-primary font-semibold hover:underline"
+                onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+              >
+                Send me a note →
+              </button>
+            </p>
+          </BentoCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FAQ: Bento FAQ ───────────────────────────────────────────────
+function FAQBento() {
+  const [openIndex, setOpenIndex] = useState(null);
+  return (
+    <section className="py-4 px-4 md:px-8" id="faq-bento">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <BentoCard className="p-8 bg-base-200" delay={0}>
+            <p className="text-primary text-xs tracking-widest uppercase font-medium mb-3">FAQ</p>
+            <h2 className="text-3xl font-black tracking-tight">Frequently Asked Questions</h2>
+          </BentoCard>
+
+          <BentoCard className="lg:col-span-2 p-8" delay={0.1}>
+            {faqList.map((item, i) => (
+              <div key={i} className={i > 0 ? "border-t border-base-300/50" : ""}>
+                <button
+                  className="w-full py-4 flex items-center justify-between text-left text-sm font-semibold hover:text-primary transition-colors"
+                  onClick={() => setOpenIndex(openIndex === i ? null : i)}
+                >
+                  {item.question}
+                  <svg className={`w-4 h-4 shrink-0 ml-2 transition-transform ${openIndex === i ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+                <div className={`overflow-hidden transition-all duration-300 ${openIndex === i ? "max-h-40 pb-4" : "max-h-0"}`}>
+                  <p className="text-base-content/50 text-sm">{item.answer}</p>
+                </div>
+              </div>
+            ))}
+          </BentoCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── CTA: Final bento ─────────────────────────────────────────────
+function CTABento({ openModal }) {
+  return (
+    <section className="py-4 pb-8 px-4 md:px-8">
+      <div className="max-w-7xl mx-auto">
+        <BentoCard className="p-12 md:p-20 bg-gradient-to-br from-neutral to-neutral/90 text-center" delay={0}>
+          <h2 className="text-3xl md:text-5xl font-black text-neutral-content tracking-tight mb-6">
+            Ready to build something great?
+          </h2>
+          <p className="text-neutral-content/50 text-lg mb-8 max-w-lg mx-auto">
+            Let&apos;s talk about your project. No strings attached.
+          </p>
+          <button
+            className="btn btn-primary btn-lg"
+            onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+          >
+            Get in touch
+          </button>
+        </BentoCard>
+      </div>
+    </section>
+  );
+}
+
+// ─── MAIN PAGE ────────────────────────────────────────────────────
+export default function Concept3() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalContent, setModalContent] = useState(null);
+  const [modalTitle, setModalTitle] = useState("");
+
+  const openModal = (content, title) => {
+    setModalContent(content);
+    setModalTitle(title || "");
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Suspense><Header openModal={openModal} /></Suspense>
+      <main className="bg-base-200">
+        <HeroBento />
+        <ToolsBento />
+        <ProblemBento />
+        <FounderBento />
+        <ServicesBento />
+        <TestimonialsBento />
+        <PricingBento openModal={openModal} />
+        <FAQBento />
+        <CTABento openModal={openModal} />
+        <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} title={modalTitle}>
+          {modalContent}
+        </Modal>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/concepts/4/page.js
+++ b/app/concepts/4/page.js
@@ -1,0 +1,555 @@
+"use client";
+
+import { Suspense, useState, useRef } from "react";
+import Image from "next/image";
+import { motion, useInView, useScroll, useTransform } from "framer-motion";
+import config from "@/config";
+import Header from "@/components/layout/Header";
+import Modal from "@/components/marketing/Modal";
+import ButtonLead from "@/components/ui/ButtonLead";
+import ButtonCheckout from "@/components/ui/ButtonCheckout";
+import Footer from "@/components/layout/Footer";
+
+/*
+ * CONCEPT 4: "Gradient Glassmorphism / Premium"
+ *
+ * Design philosophy: Rich gradients, glassmorphism cards with backdrop blur,
+ * glowing orbs, and a dark premium feel. Inspired by Raycast, Arc Browser,
+ * and Linear's dark mode. The whole page has a "premium software" aesthetic
+ * with frosted glass panels over a gradient-rich background.
+ */
+
+const testimonials = [
+  { rating: 5, text: "Gene isn't just a coder - he understands that code has to ship and ultimately drive business results. He's creative, human, and has accommodated a lot of weird ideas for us over the years, usually making them better in the execution.", author: "Andy F", authorTitle: "GMB Fitness Founder", authorImage: "/testimonials/andy.jpeg" },
+  { rating: 5, text: "Your UX is great! Best onboarding I've seen in any course period.", author: "Omar Z", authorTitle: "Praxis User, Founder of $100 MBA podcast", authorImage: "/testimonials/omar-zenhom.jpeg" },
+  { rating: 5, text: "Since the new site went live, we've received nothing but positive feedback from the teachers and coaches who use it", author: "Katy W", authorTitle: "Program Director, The Art of Learning Foundation", authorImage: "/testimonials/katy-wells.jpeg" },
+  { rating: 5, text: "I also have to mention the Praxis platform (build by Lansky) - it's the best in the business!.", author: "Mark", authorTitle: "Praxis User", authorImage: "/testimonials/lion.jpeg" },
+  { rating: 5, text: "A consummate professional with exceptional patience Gene worked tirelessly to deliver the work I wanted.", author: "Shawn S", authorTitle: "iLiveFit Founder, USAF Captain", authorImage: "/testimonials/shawn-swift.jpeg" },
+];
+
+const faqList = [
+  { question: "What types of web applications do you specialize in building?", answer: "We specialize in high-performance web applications, custom e-commerce solutions, and conversion-focused marketing sites." },
+  { question: "What's the difference between a web application and a website?", answer: "A website primarily delivers information. A web application is interactive software that lets users perform complex tasks, manipulate data, and create content in real-time." },
+  { question: "How can I sell more online?", answer: "High-converting checkout pages, mobile-first design, smart upsell systems, subscription options, performance optimization, and analytics integration." },
+  { question: "Can you build an app that does X?", answer: "Anything can be built. Our goal is to find the leanest version of your product. That's the hard part." },
+  { question: "How do you measure success?", answer: "Through concrete business outcomes: conversion rates, user engagement, retention metrics, lead generation, and performance benchmarks." },
+  { question: "I have another question", answer: "Contact us at hi@lansky.tech" },
+];
+
+// Reusable glass card
+const GlassCard = ({ children, className = "", glow = false }) => (
+  <div className={`relative rounded-2xl border border-white/[0.08] overflow-hidden ${className}`}
+    style={{
+      background: "linear-gradient(135deg, rgba(255,255,255,0.05) 0%, rgba(255,255,255,0.02) 100%)",
+      backdropFilter: "blur(20px)",
+    }}
+  >
+    {glow && <div className="absolute -top-20 -right-20 w-40 h-40 bg-primary/20 rounded-full blur-3xl pointer-events-none" />}
+    {children}
+  </div>
+);
+
+// Background orbs
+const BackgroundOrbs = () => (
+  <div className="fixed inset-0 pointer-events-none overflow-hidden z-0">
+    <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-[#0066CC]/10 rounded-full blur-[120px] animate-pulse" />
+    <div className="absolute bottom-1/3 right-1/4 w-80 h-80 bg-[#FFCC00]/8 rounded-full blur-[100px] animate-pulse" style={{ animationDelay: "2s" }} />
+    <div className="absolute top-2/3 left-1/2 w-64 h-64 bg-purple-500/8 rounded-full blur-[80px] animate-pulse" style={{ animationDelay: "4s" }} />
+  </div>
+);
+
+// ─── HERO: Centered with glow ─────────────────────────────────────
+function HeroGlass() {
+  return (
+    <section className="relative min-h-screen flex items-center justify-center px-8 overflow-hidden">
+      {/* Central glow */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-radial from-primary/20 via-transparent to-transparent rounded-full blur-3xl pointer-events-none" />
+
+      <div className="relative z-10 max-w-5xl mx-auto text-center py-32">
+        <motion.div
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 1, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm mb-8">
+            <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+            <span className="text-sm text-base-content/60">Available for new projects</span>
+          </div>
+
+          <h1 className="text-5xl md:text-7xl lg:text-8xl font-black tracking-tight leading-[0.95] mb-8">
+            <span className="bg-clip-text text-transparent bg-gradient-to-b from-base-content to-base-content/40">
+              Web tech that
+            </span>
+            <br />
+            <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] via-[#4488DD] to-[#FFCC00]">
+              moves the needle.
+            </span>
+          </h1>
+
+          <p className="text-base-content/40 text-xl md:text-2xl max-w-2xl mx-auto leading-relaxed mb-12">
+            You&apos;re small but <strong className="text-base-content/70">mighty, and ready to grow</strong> — you just need the right tech to do it. We can build that for you. <em>Fast.</em>
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <a href="#prices-glass" className="btn btn-primary btn-lg px-8">
+              Get started
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+            </a>
+            <a href="#solutions-glass" className="btn btn-ghost btn-lg border border-white/10">
+              See our work
+            </a>
+          </div>
+        </motion.div>
+
+        {/* Floating image with glass frame */}
+        <motion.div
+          initial={{ opacity: 0, y: 60 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 1, delay: 0.4, ease: [0.16, 1, 0.3, 1] }}
+          className="mt-20"
+        >
+          <GlassCard className="p-2 max-w-3xl mx-auto" glow>
+            <Image
+              src="/lansky-solutions.png"
+              alt="Lansky Solutions"
+              width={7041}
+              height={5788}
+              className="w-full h-auto rounded-xl"
+              priority
+            />
+          </GlassCard>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TOOLS: Glass tool cards ──────────────────────────────────────
+function ToolsGlass() {
+  const [url, setUrl] = useState("");
+  const handleTestPage = (e) => {
+    e.preventDefault();
+    let testUrl = url.trim();
+    if (!testUrl) return;
+    if (!/^https?:\/\//i.test(testUrl)) testUrl = `https://${testUrl}`;
+    window.open(`https://landingpage.report?url=${encodeURIComponent(testUrl)}`, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="relative py-24 md:py-32 px-8">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-16">
+          <span className="text-sm text-primary/80 font-medium tracking-widest uppercase">Free Tools</span>
+          <h2 className="text-4xl md:text-5xl font-black tracking-tight mt-4 mb-4">
+            <span className="bg-clip-text text-transparent bg-gradient-to-b from-base-content to-base-content/50">
+              Tools to Help Your Business Grow
+            </span>
+          </h2>
+          <p className="text-base-content/40 text-lg">We build tools that solve real problems.</p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-6">
+          <GlassCard className="p-8" glow>
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-lg">🎯</div>
+              <h3 className="font-bold text-xl">Landing Page Report</h3>
+            </div>
+            <p className="text-base-content/50 mb-6">Get instant AI-powered feedback on your landing page&apos;s effectiveness.</p>
+            <form onSubmit={handleTestPage} className="space-y-3">
+              <input type="url" placeholder="https://your-landing-page.com" value={url} onChange={(e) => setUrl(e.target.value)} className="input input-bordered w-full bg-white/5 border-white/10" required />
+              <button type="submit" className="btn btn-primary w-full">Analyze Your Page</button>
+            </form>
+          </GlassCard>
+
+          <GlassCard className="p-8" glow>
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-green-500 to-cyan-600 flex items-center justify-center text-lg">🚀</div>
+              <h3 className="font-bold text-xl">Compute Prices</h3>
+            </div>
+            <p className="text-base-content/50 mb-6">Compare GPU prices across 27+ providers instantly.</p>
+            <div className="flex flex-wrap gap-2 mb-6">
+              {["H100", "A100", "RTX 4090", "L40S", "+20 more"].map((g) => (
+                <span key={g} className="text-xs border border-white/10 text-base-content/50 px-2.5 py-1 rounded-full">{g}</span>
+              ))}
+            </div>
+            <a href="https://computeprices.com" target="_blank" rel="noopener noreferrer" className="btn btn-primary w-full">Compare GPU Prices</a>
+          </GlassCard>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── PROBLEM: Glass panels ────────────────────────────────────────
+function ProblemGlass() {
+  return (
+    <section className="relative py-24 md:py-32 px-8" id="problem-glass">
+      <div className="max-w-5xl mx-auto">
+        <div className="text-center mb-16">
+          <span className="text-sm text-error/80 font-medium tracking-widest uppercase">The Problem</span>
+          <h2 className="text-4xl md:text-6xl font-black tracking-tight mt-4 mb-6">
+            <span className="bg-clip-text text-transparent bg-gradient-to-b from-base-content to-base-content/50">
+              70% of tech projects fail
+            </span>
+          </h2>
+          <p className="text-base-content/40 text-lg max-w-xl mx-auto">
+            Not finding a good enough solution, too much complexity, ignoring users... There&apos;s so many ways good ideas can lose steam.
+          </p>
+        </div>
+
+        {/* Failure flow as a glass pipeline */}
+        <div className="flex flex-col md:flex-row gap-4 justify-center mb-16">
+          {[
+            { emoji: "💡", label: "Beautiful new idea" },
+            { emoji: "👩🏻‍💻", label: "Design tons of features" },
+            { emoji: "💰", label: "Project overruns" },
+            { emoji: "😤", label: "Project fails" },
+          ].map((step, i) => (
+            <motion.div key={step.label}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="flex-1"
+            >
+              <GlassCard className="p-6 text-center">
+                <span className="text-3xl block mb-2">{step.emoji}</span>
+                <p className="font-semibold text-sm">{step.label}</p>
+              </GlassCard>
+              {i < 3 && (
+                <div className="flex justify-center py-2 md:hidden">
+                  <svg className="w-4 h-4 text-base-content/20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7" /></svg>
+                </div>
+              )}
+            </motion.div>
+          ))}
+        </div>
+
+        <GlassCard className="p-8 md:p-12 max-w-3xl mx-auto">
+          <p className="text-base-content/60 mb-6">Here&apos;s where most businesses run into trouble:</p>
+          <div className="space-y-3 mb-8">
+            {[
+              "Developers focus on the task, not the full picture",
+              "They don't understand your business goals",
+              "Complexity means more billable hours",
+              "User experience is an afterthought",
+              "Tech jargon instead of clear communication",
+            ].map((item, i) => (
+              <div key={i} className="flex items-start gap-3">
+                <div className="w-1 h-1 rounded-full bg-primary/50 mt-2.5 shrink-0" />
+                <span className="text-base-content/50">{item}</span>
+              </div>
+            ))}
+          </div>
+          <div className="pt-6 border-t border-white/[0.06]">
+            <p className="text-base-content/40 mb-2">Projects run over budget, over schedule, or never ship.</p>
+            <p className="font-bold text-lg bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">
+              You need development designed for growth.
+            </p>
+          </div>
+        </GlassCard>
+      </div>
+    </section>
+  );
+}
+
+// ─── SERVICES: Glass grid ─────────────────────────────────────────
+function ServicesGlass() {
+  return (
+    <section className="relative py-24 md:py-32 px-8" id="solutions-glass">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-16">
+          <span className="text-sm text-primary/80 font-medium tracking-widest uppercase">What we do</span>
+          <h2 className="text-4xl md:text-5xl font-black tracking-tight mt-4 mb-4">
+            <span className="bg-clip-text text-transparent bg-gradient-to-b from-base-content to-base-content/50">
+              Start small. Iterate. Build lean.
+            </span>
+          </h2>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          {[
+            { icon: "📺", title: "Web Apps", desc: "Get a custom-built, high-performance web application that's lean, profitable, and designed to grow with you.", gradient: "from-blue-500/20 via-transparent to-transparent" },
+            { icon: "💳", title: "Ecommerce", desc: "Create seamless and effective e-commerce flows that take users from discovery to checkout in a fully integrated funnel.", gradient: "from-green-500/20 via-transparent to-transparent" },
+            { icon: "🎨", title: "Marketing Sites", desc: "Convert visitors into customers with fast-loading landing pages, immersive product showcases, and easy content management.", gradient: "from-orange-500/20 via-transparent to-transparent" },
+          ].map((service, i) => (
+            <motion.div
+              key={service.title}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+            >
+              <GlassCard className="p-8 h-full group hover:border-white/[0.15] transition-colors">
+                <div className={`absolute inset-0 bg-gradient-to-b ${service.gradient} opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none rounded-2xl`} />
+                <div className="relative">
+                  <span className="text-4xl block mb-6">{service.icon}</span>
+                  <h3 className="text-xl font-bold mb-3">{service.title}</h3>
+                  <p className="text-base-content/40 leading-relaxed">{service.desc}</p>
+                </div>
+              </GlassCard>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── TESTIMONIALS: Glass cards ────────────────────────────────────
+function TestimonialsGlass() {
+  return (
+    <section className="relative py-24 md:py-32 px-8">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-16">
+          <h2 className="text-4xl md:text-5xl font-black tracking-tight">
+            <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">
+              What people say about working with us
+            </span>
+          </h2>
+        </div>
+
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {testimonials.map((t, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.08 }}
+            >
+              <GlassCard className={`p-6 h-full ${i === 0 ? "md:col-span-2 lg:col-span-1" : ""}`}>
+                <div className="flex mb-3">
+                  {[...Array(t.rating)].map((_, j) => (
+                    <svg key={j} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5 text-warning">
+                      <path fillRule="evenodd" d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z" clipRule="evenodd" />
+                    </svg>
+                  ))}
+                </div>
+                <p className="text-base-content/60 text-sm leading-relaxed mb-4">&ldquo;{t.text}&rdquo;</p>
+                <div className="flex items-center gap-3 mt-auto">
+                  <Image src={t.authorImage} alt={t.author} width={32} height={32} className="rounded-full ring-1 ring-white/10" />
+                  <div>
+                    <p className="font-medium text-sm">{t.author}</p>
+                    <p className="text-xs text-base-content/30">{t.authorTitle}</p>
+                  </div>
+                </div>
+              </GlassCard>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FOUNDER: Glass profile ───────────────────────────────────────
+function FounderGlass() {
+  return (
+    <section className="relative py-24 md:py-32 px-8" id="hello-glass">
+      <div className="max-w-4xl mx-auto">
+        <GlassCard className="p-8 md:p-16" glow>
+          <div className="flex flex-col md:flex-row gap-8 md:gap-12 items-center">
+            <div className="shrink-0">
+              <div className="relative">
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/30 to-secondary/30 rounded-full blur-2xl" />
+                <Image
+                  src="/gene-kobilansky-headshot-yellow-bg.png"
+                  alt="Gene Kobilansky"
+                  width={150}
+                  height={150}
+                  className="relative rounded-full ring-2 ring-white/10"
+                />
+              </div>
+            </div>
+            <div>
+              <span className="text-sm text-primary/80 font-medium tracking-widest uppercase">Hello</span>
+              <h2 className="text-3xl md:text-4xl font-black tracking-tight mt-3 mb-6">
+                What if web development could be{" "}
+                <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+                  faster, easier, and simpler?
+                </span>
+              </h2>
+              <div className="text-base-content/40 space-y-4 leading-relaxed">
+                <p>Hi, I&apos;m Gene Kobilansky, founder of Lansky Tech, and that is <strong className="text-base-content/70">exactly my specialty</strong>.</p>
+                <p>I&apos;ve worked with companies of all sizes — from small charity organizations to McDonald&apos;s, Amazon, GE, and Samsung. They all needed the right tech solutions with as little bloat as possible.</p>
+              </div>
+              <div className="flex items-center gap-4 mt-6">
+                <Image src="/gk-initials-white.png" alt="Signature" width={1920} height={1080} className="max-w-32 opacity-40" />
+              </div>
+              <div className="mt-6">
+                <ButtonLead />
+              </div>
+            </div>
+          </div>
+        </GlassCard>
+      </div>
+    </section>
+  );
+}
+
+// ─── PRICING: Glass cards ─────────────────────────────────────────
+function PricingGlass({ openModal }) {
+  return (
+    <section className="relative py-24 md:py-32 px-8" id="prices-glass">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-16">
+          <span className="text-sm text-primary/80 font-medium tracking-widest uppercase">Pricing</span>
+          <h2 className="text-4xl md:text-5xl font-black tracking-tight mt-4 mb-4">
+            <span className="bg-clip-text text-transparent bg-gradient-to-b from-base-content to-base-content/50">
+              Simple Pricing to Get Started
+            </span>
+          </h2>
+          <p className="text-base-content/40 text-lg max-w-xl mx-auto">Transparent pricing. No overhead. No surprises.</p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          {config.stripe.plans.map((plan, i) => (
+            <motion.div
+              key={plan.priceId}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+            >
+              <GlassCard className={`p-8 h-full flex flex-col ${plan.isFeatured ? "ring-1 ring-primary/50" : ""}`} glow={plan.isFeatured}>
+                {plan.isFeatured && (
+                  <div className="inline-flex self-start items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 border border-primary/20 mb-4">
+                    <div className="w-1.5 h-1.5 rounded-full bg-primary" />
+                    <span className="text-xs text-primary font-medium">Most Popular</span>
+                  </div>
+                )}
+                <h3 className="text-lg font-bold mb-2">{plan.name}</h3>
+                <p className="text-base-content/40 text-sm mb-6 flex-grow">{plan.description}</p>
+                <ul className="space-y-2.5 mb-8">
+                  {plan.features.map((f, j) => (
+                    <li key={j} className="text-sm text-base-content/50 flex items-start gap-2">
+                      <svg className="w-4 h-4 text-primary/60 shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                      <span>{f.name}</span>
+                    </li>
+                  ))}
+                </ul>
+                <ButtonCheckout priceId={plan.priceId} ctaButtonText={plan.ctaButtonText} openModal={openModal} />
+              </GlassCard>
+            </motion.div>
+          ))}
+        </div>
+
+        <div className="mt-16 text-center">
+          <p className="text-base-content/30">
+            Need something custom?{" "}
+            <button
+              className="text-primary/80 hover:text-primary transition-colors"
+              onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+            >
+              Let&apos;s talk →
+            </button>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FAQ: Glass accordion ─────────────────────────────────────────
+function FAQGlass() {
+  const [openIndex, setOpenIndex] = useState(null);
+  return (
+    <section className="relative py-24 md:py-32 px-8" id="faq-glass">
+      <div className="max-w-3xl mx-auto">
+        <div className="text-center mb-16">
+          <h2 className="text-4xl font-black tracking-tight">
+            <span className="bg-clip-text text-transparent bg-gradient-to-b from-base-content to-base-content/50">
+              Frequently Asked Questions
+            </span>
+          </h2>
+        </div>
+
+        <div className="space-y-3">
+          {faqList.map((item, i) => (
+            <GlassCard key={i} className="overflow-visible">
+              <button
+                className="w-full p-5 flex items-center justify-between text-left font-medium hover:text-primary transition-colors"
+                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+              >
+                <span className="pr-4">{item.question}</span>
+                <svg className={`w-4 h-4 shrink-0 transition-transform text-base-content/30 ${openIndex === i ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              <div className={`overflow-hidden transition-all duration-300 ${openIndex === i ? "max-h-40 pb-5 px-5" : "max-h-0"}`}>
+                <p className="text-base-content/40 text-sm leading-relaxed">{item.answer}</p>
+              </div>
+            </GlassCard>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── CTA: Gradient glass ──────────────────────────────────────────
+function CTAGlass({ openModal }) {
+  return (
+    <section className="relative py-24 md:py-32 px-8">
+      <div className="max-w-4xl mx-auto">
+        <GlassCard className="p-12 md:p-20 text-center overflow-hidden" glow>
+          <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10 pointer-events-none" />
+          <div className="relative">
+            <h2 className="text-4xl md:text-6xl font-black tracking-tight mb-6">
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">
+                Ready to build something great?
+              </span>
+            </h2>
+            <p className="text-base-content/40 text-lg mb-10 max-w-lg mx-auto">
+              Let&apos;s talk about your project. No strings attached.
+            </p>
+            <button
+              className="btn btn-primary btn-lg px-8"
+              onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+            >
+              Get in touch
+            </button>
+          </div>
+        </GlassCard>
+      </div>
+    </section>
+  );
+}
+
+// ─── MAIN PAGE ────────────────────────────────────────────────────
+export default function Concept4() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalContent, setModalContent] = useState(null);
+  const [modalTitle, setModalTitle] = useState("");
+
+  const openModal = (content, title) => {
+    setModalContent(content);
+    setModalTitle(title || "");
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Suspense><Header openModal={openModal} /></Suspense>
+      <main className="relative bg-base-100 overflow-hidden">
+        <BackgroundOrbs />
+        <div className="relative z-10">
+          <HeroGlass />
+          <ToolsGlass />
+          <ProblemGlass />
+          <FounderGlass />
+          <ServicesGlass />
+          <TestimonialsGlass />
+          <PricingGlass openModal={openModal} />
+          <FAQGlass />
+          <CTAGlass openModal={openModal} />
+        </div>
+        <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} title={modalTitle}>
+          {modalContent}
+        </Modal>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/concepts/5/page.js
+++ b/app/concepts/5/page.js
@@ -1,0 +1,540 @@
+"use client";
+
+import { Suspense, useState, useRef } from "react";
+import Image from "next/image";
+import { motion, useInView, useScroll, useTransform } from "framer-motion";
+import config from "@/config";
+import Header from "@/components/layout/Header";
+import Modal from "@/components/marketing/Modal";
+import ButtonLead from "@/components/ui/ButtonLead";
+import ButtonCheckout from "@/components/ui/ButtonCheckout";
+import Footer from "@/components/layout/Footer";
+
+/*
+ * CONCEPT 5: "Vertical Rhythm / Scroll-Reveal Storytelling"
+ *
+ * Design philosophy: Full-viewport sections that reveal as you scroll.
+ * Each section is a "chapter" with dramatic reveals, parallax elements,
+ * and a narrative arc. Inspired by Apple product pages, Stripe's annual
+ * reports, and long-form storytelling sites. Each section takes the
+ * full viewport height and content fades/slides in on scroll.
+ */
+
+const testimonials = [
+  { rating: 5, text: "Gene isn't just a coder - he understands that code has to ship and ultimately drive business results. He's creative, human, and has accommodated a lot of weird ideas for us over the years, usually making them better in the execution.", author: "Andy F", authorTitle: "GMB Fitness Founder", authorImage: "/testimonials/andy.jpeg" },
+  { rating: 5, text: "Your UX is great! Best onboarding I've seen in any course period.", author: "Omar Z", authorTitle: "Praxis User, Founder of $100 MBA podcast", authorImage: "/testimonials/omar-zenhom.jpeg" },
+  { rating: 5, text: "Since the new site went live, we've received nothing but positive feedback from the teachers and coaches who use it", author: "Katy W", authorTitle: "Program Director, The Art of Learning Foundation", authorImage: "/testimonials/katy-wells.jpeg" },
+  { rating: 5, text: "I also have to mention the Praxis platform (build by Lansky) - it's the best in the business!.", author: "Mark", authorTitle: "Praxis User", authorImage: "/testimonials/lion.jpeg" },
+  { rating: 5, text: "A consummate professional with exceptional patience Gene worked tirelessly to deliver the work I wanted.", author: "Shawn S", authorTitle: "iLiveFit Founder, USAF Captain", authorImage: "/testimonials/shawn-swift.jpeg" },
+];
+
+const faqList = [
+  { question: "What types of web applications do you specialize in building?", answer: "We specialize in high-performance web applications, custom e-commerce solutions, and conversion-focused marketing sites." },
+  { question: "What's the difference between a web application and a website?", answer: "A website primarily delivers information. A web application is interactive software that lets users perform complex tasks, manipulate data, and create content in real-time." },
+  { question: "How can I sell more online?", answer: "High-converting checkout pages, mobile-first design, smart upsell systems, subscription options, performance optimization, and analytics integration." },
+  { question: "Can you build an app that does X?", answer: "Anything can be built. Our goal is to find the leanest version of your product. That's the hard part." },
+  { question: "How do you measure success?", answer: "Through concrete business outcomes: conversion rates, user engagement, retention metrics, lead generation, and performance benchmarks." },
+  { question: "I have another question", answer: "Contact us at hi@lansky.tech" },
+];
+
+// Reusable reveal wrapper
+const RevealSection = ({ children, className = "" }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 60 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-15%" }}
+      transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+// ─── CHAPTER 1: HERO ──────────────────────────────────────────────
+function ChapterHero() {
+  const ref = useRef(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ["start start", "end start"] });
+  const opacity = useTransform(scrollYProgress, [0, 0.5], [1, 0]);
+  const y = useTransform(scrollYProgress, [0, 0.5], [0, -100]);
+
+  return (
+    <section ref={ref} className="relative min-h-screen flex items-center justify-center overflow-hidden">
+      {/* Gradient background */}
+      <div className="absolute inset-0">
+        <div className="absolute inset-0 bg-gradient-to-b from-neutral via-neutral/95 to-base-100" />
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[800px] bg-gradient-radial from-primary/15 via-transparent to-transparent rounded-full blur-3xl" />
+      </div>
+
+      <motion.div style={{ opacity, y }} className="relative z-10 text-center px-8 max-w-5xl mx-auto">
+        <motion.div
+          initial={{ opacity: 0, y: 50 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <p className="text-primary/60 text-sm tracking-[0.4em] uppercase mb-8">Lansky Tech</p>
+          <h1 className="text-6xl md:text-8xl lg:text-[10rem] font-black tracking-tighter leading-[0.85]">
+            <span className="text-neutral-content/90">Web</span>
+            <br />
+            <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">tech.</span>
+          </h1>
+          <p className="text-neutral-content/40 text-xl md:text-2xl mt-8 max-w-lg mx-auto leading-relaxed">
+            That moves the needle. That ships fast. That scales with you.
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.5, duration: 1 }}
+          className="absolute bottom-12 left-1/2 -translate-x-1/2"
+        >
+          <motion.div
+            animate={{ y: [0, 8, 0] }}
+            transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+            className="flex flex-col items-center gap-2"
+          >
+            <span className="text-neutral-content/20 text-xs tracking-widest uppercase">Scroll</span>
+            <div className="w-px h-12 bg-gradient-to-b from-neutral-content/20 to-transparent" />
+          </motion.div>
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}
+
+// ─── CHAPTER 2: THE PROMISE ───────────────────────────────────────
+function ChapterPromise() {
+  return (
+    <section className="min-h-screen flex items-center justify-center px-8 py-24">
+      <div className="max-w-3xl mx-auto">
+        <RevealSection>
+          <p className="text-7xl md:text-9xl font-black text-base-content/[0.03] absolute -top-8 left-0 select-none pointer-events-none">01</p>
+          <div className="relative">
+            <p className="text-primary/60 text-sm tracking-[0.3em] uppercase mb-8">Chapter One</p>
+            <h2 className="text-4xl md:text-6xl font-black tracking-tight leading-[1.1] mb-8">
+              You&apos;re small but mighty, and ready to grow.
+            </h2>
+            <p className="text-base-content/40 text-xl leading-relaxed">
+              You just need the right tech to do it. We can build that for you. <em className="text-base-content/60">Fast.</em>
+            </p>
+          </div>
+        </RevealSection>
+
+        <RevealSection className="mt-24">
+          <div className="flex justify-center">
+            <Image
+              src="/lansky-solutions.png"
+              alt="Lansky Solutions"
+              width={7041}
+              height={5788}
+              className="w-full max-w-2xl h-auto rounded-2xl"
+              priority
+            />
+          </div>
+        </RevealSection>
+      </div>
+    </section>
+  );
+}
+
+// ─── CHAPTER 3: THE PROBLEM ───────────────────────────────────────
+function ChapterProblem() {
+  return (
+    <section className="min-h-screen flex items-center justify-center px-8 py-24 bg-neutral" id="problem-story">
+      <div className="max-w-3xl mx-auto">
+        <RevealSection>
+          <p className="text-primary/60 text-sm tracking-[0.3em] uppercase mb-8">Chapter Two</p>
+          <h2 className="text-5xl md:text-7xl font-black text-neutral-content tracking-tight leading-[0.95] mb-12">
+            70% of tech projects
+            <br />
+            <span className="text-error/70">fail.</span>
+          </h2>
+        </RevealSection>
+
+        <RevealSection>
+          <p className="text-neutral-content/40 text-xl leading-relaxed mb-16">
+            Not finding a good enough solution, too much complexity, ignoring users... There&apos;s so many ways good ideas can lose steam.
+          </p>
+        </RevealSection>
+
+        {/* Steps revealed one by one */}
+        <div className="space-y-6">
+          {[
+            { emoji: "💡", text: "It starts with a beautiful new idea", line: "bg-gradient-to-r from-success/50 to-success/0" },
+            { emoji: "👩🏻‍💻", text: "Then you design tons of features", line: "bg-gradient-to-r from-info/50 to-info/0" },
+            { emoji: "💰", text: "The project overruns budget", line: "bg-gradient-to-r from-warning/50 to-warning/0" },
+            { emoji: "😤", text: "And the project fails.", line: "bg-gradient-to-r from-error/50 to-error/0" },
+          ].map((step, i) => (
+            <RevealSection key={step.text}>
+              <div className="flex items-center gap-6">
+                <span className="text-4xl shrink-0">{step.emoji}</span>
+                <div className="flex-1">
+                  <p className="text-neutral-content/70 text-xl font-medium">{step.text}</p>
+                  <div className={`h-px mt-3 ${step.line}`} />
+                </div>
+              </div>
+            </RevealSection>
+          ))}
+        </div>
+
+        <RevealSection className="mt-20">
+          <div className="border-l-2 border-primary/30 pl-8">
+            <p className="text-neutral-content/50 text-lg leading-relaxed mb-4">
+              Developers who don&apos;t see the big picture. Who don&apos;t understand your business. Who profit from complexity.
+            </p>
+            <p className="text-2xl font-bold text-neutral-content">
+              You need development designed for growth.
+            </p>
+          </div>
+        </RevealSection>
+      </div>
+    </section>
+  );
+}
+
+// ─── CHAPTER 4: THE SOLUTION ──────────────────────────────────────
+function ChapterSolution() {
+  return (
+    <section className="min-h-screen flex items-center justify-center px-8 py-24" id="solutions-story">
+      <div className="max-w-4xl mx-auto">
+        <RevealSection>
+          <p className="text-primary/60 text-sm tracking-[0.3em] uppercase mb-8">Chapter Three</p>
+          <h2 className="text-4xl md:text-6xl font-black tracking-tight leading-tight mb-20">
+            We start small & iterate
+            <br />
+            to build a <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">lean, profitable product.</span>
+          </h2>
+        </RevealSection>
+
+        <div className="grid md:grid-cols-3 gap-12 md:gap-8">
+          {[
+            { icon: "📺", title: "Web Apps", desc: "Custom-built, high-performance web applications that are lean, profitable, and designed to grow with you." },
+            { icon: "💳", title: "Ecommerce", desc: "Seamless e-commerce flows from discovery to checkout in a fully integrated funnel." },
+            { icon: "🎨", title: "Marketing Sites", desc: "Fast-loading landing pages, immersive showcases, and easy content management that converts." },
+          ].map((service, i) => (
+            <RevealSection key={service.title}>
+              <div className="text-center md:text-left">
+                <span className="text-5xl block mb-6">{service.icon}</span>
+                <h3 className="text-2xl font-bold mb-4">{service.title}</h3>
+                <p className="text-base-content/40 leading-relaxed">{service.desc}</p>
+              </div>
+            </RevealSection>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── CHAPTER 5: SOCIAL PROOF ──────────────────────────────────────
+function ChapterProof() {
+  return (
+    <section className="py-24 md:py-32 bg-base-200 px-8">
+      <div className="max-w-4xl mx-auto">
+        <RevealSection>
+          <p className="text-primary/60 text-sm tracking-[0.3em] uppercase mb-8">Chapter Four</p>
+          <h2 className="text-4xl md:text-5xl font-black tracking-tight mb-16">
+            Don&apos;t take our word for it.
+          </h2>
+        </RevealSection>
+
+        <div className="space-y-12">
+          {testimonials.map((t, i) => (
+            <RevealSection key={i}>
+              <div className={`flex flex-col ${i % 2 === 0 ? "md:flex-row" : "md:flex-row-reverse"} gap-6 items-start`}>
+                <div className="shrink-0">
+                  <Image src={t.authorImage} alt={t.author} width={64} height={64} className="rounded-full" />
+                </div>
+                <div className={`flex-1 ${i % 2 !== 0 ? "md:text-right" : ""}`}>
+                  <div className={`flex mb-2 ${i % 2 !== 0 ? "md:justify-end" : ""}`}>
+                    {[...Array(t.rating)].map((_, j) => (
+                      <svg key={j} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 text-warning">
+                        <path fillRule="evenodd" d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z" clipRule="evenodd" />
+                      </svg>
+                    ))}
+                  </div>
+                  <p className={`text-lg leading-relaxed text-base-content/60 mb-3 ${i === 0 ? "text-xl md:text-2xl" : ""}`}>
+                    &ldquo;{t.text}&rdquo;
+                  </p>
+                  <p className="text-sm"><span className="font-medium">{t.author}</span> <span className="text-base-content/30">/ {t.authorTitle}</span></p>
+                </div>
+              </div>
+            </RevealSection>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── CHAPTER 6: MEET THE FOUNDER ──────────────────────────────────
+function ChapterFounder() {
+  return (
+    <section className="min-h-screen flex items-center justify-center px-8 py-24" id="hello-story">
+      <div className="max-w-3xl mx-auto text-center">
+        <RevealSection>
+          <p className="text-primary/60 text-sm tracking-[0.3em] uppercase mb-8">Chapter Five</p>
+          <Image
+            src="/gene-kobilansky-headshot-yellow-bg.png"
+            alt="Gene Kobilansky"
+            width={160}
+            height={160}
+            className="rounded-full mx-auto mb-8"
+          />
+          <h2 className="text-4xl md:text-6xl font-black tracking-tight leading-tight mb-8">
+            What if web development could be{" "}
+            <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+              faster, easier, and simpler?
+            </span>
+          </h2>
+        </RevealSection>
+
+        <RevealSection>
+          <div className="text-left text-base-content/40 text-lg leading-[1.9] space-y-6 max-w-2xl mx-auto">
+            <p>Hi, I&apos;m Gene Kobilansky, founder of Lansky Tech, and that is <strong className="text-base-content/70">exactly my specialty</strong>.</p>
+            <p>I&apos;ve worked with companies of all sizes — from small charity organizations just getting off the ground, to some of the biggest companies in the world, like McDonald&apos;s, Amazon, GE, and Samsung.</p>
+            <p>They all needed the right tech solutions to help them grow, with as little tech bloat as possible.</p>
+            <p className="text-base-content/60 font-medium">I look forward to hearing from you.</p>
+          </div>
+          <div className="flex justify-center mt-8">
+            <Image src="/gk-initials-white.png" alt="Signature" width={1920} height={1080} className="max-w-40 opacity-50" />
+          </div>
+          <div className="mt-8">
+            <ButtonLead />
+          </div>
+        </RevealSection>
+      </div>
+    </section>
+  );
+}
+
+// ─── TOOLS ────────────────────────────────────────────────────────
+function ChapterTools() {
+  const [url, setUrl] = useState("");
+  const handleTestPage = (e) => {
+    e.preventDefault();
+    let testUrl = url.trim();
+    if (!testUrl) return;
+    if (!/^https?:\/\//i.test(testUrl)) testUrl = `https://${testUrl}`;
+    window.open(`https://landingpage.report?url=${encodeURIComponent(testUrl)}`, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="py-24 md:py-32 bg-base-200 px-8">
+      <div className="max-w-4xl mx-auto">
+        <RevealSection>
+          <p className="text-primary/60 text-sm tracking-[0.3em] uppercase mb-8">Free Tools</p>
+          <h2 className="text-4xl md:text-5xl font-black tracking-tight mb-16">
+            Tools to Help Your Business Grow
+          </h2>
+        </RevealSection>
+
+        <div className="space-y-8">
+          <RevealSection>
+            <div className="bg-base-100 rounded-2xl p-8 md:p-12 border border-base-300">
+              <div className="flex flex-col md:flex-row gap-8">
+                <div className="md:w-1/2">
+                  <span className="text-4xl block mb-4">🎯</span>
+                  <h3 className="text-2xl font-bold mb-2">Landing Page Report</h3>
+                  <p className="text-base-content/50">Get instant AI-powered feedback on your landing page&apos;s effectiveness.</p>
+                </div>
+                <div className="md:w-1/2">
+                  <form onSubmit={handleTestPage} className="space-y-3">
+                    <input type="url" placeholder="https://your-landing-page.com" value={url} onChange={(e) => setUrl(e.target.value)} className="input input-bordered w-full" required />
+                    <button type="submit" className="btn btn-primary w-full">Analyze Your Page</button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </RevealSection>
+
+          <RevealSection>
+            <div className="bg-base-100 rounded-2xl p-8 md:p-12 border border-base-300">
+              <div className="flex flex-col md:flex-row gap-8 items-center">
+                <div className="md:w-1/2">
+                  <span className="text-4xl block mb-4">🚀</span>
+                  <h3 className="text-2xl font-bold mb-2">Compute Prices</h3>
+                  <p className="text-base-content/50">Compare GPU prices across 27+ providers instantly.</p>
+                  <div className="flex flex-wrap gap-2 mt-4">
+                    {["H100", "A100", "RTX 4090", "L40S", "+20 more"].map((g) => (
+                      <span key={g} className="badge badge-outline badge-sm">{g}</span>
+                    ))}
+                  </div>
+                </div>
+                <div className="md:w-1/2">
+                  <a href="https://computeprices.com" target="_blank" rel="noopener noreferrer" className="btn btn-primary w-full">Compare GPU Prices</a>
+                </div>
+              </div>
+            </div>
+          </RevealSection>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── PRICING ──────────────────────────────────────────────────────
+function ChapterPricing({ openModal }) {
+  return (
+    <section className="py-24 md:py-32 px-8" id="prices-story">
+      <div className="max-w-5xl mx-auto">
+        <RevealSection>
+          <div className="text-center mb-16">
+            <p className="text-primary/60 text-sm tracking-[0.3em] uppercase mb-8">Chapter Six</p>
+            <h2 className="text-4xl md:text-6xl font-black tracking-tight mb-4">
+              Simple Pricing
+            </h2>
+            <p className="text-base-content/40 text-lg">Transparent. No overhead. No surprises.</p>
+          </div>
+        </RevealSection>
+
+        <div className="grid md:grid-cols-3 gap-8">
+          {config.stripe.plans.map((plan, i) => (
+            <RevealSection key={plan.priceId}>
+              <div className={`h-full flex flex-col p-8 rounded-2xl border ${
+                plan.isFeatured
+                  ? "border-primary/30 bg-primary/5 shadow-lg shadow-primary/5"
+                  : "border-base-300 bg-base-100"
+              }`}>
+                {plan.isFeatured && (
+                  <span className="text-xs text-primary font-bold tracking-widest uppercase mb-4">Most Popular</span>
+                )}
+                <h3 className="text-lg font-bold mb-2">{plan.name}</h3>
+                <p className="text-base-content/40 text-sm mb-6 flex-grow">{plan.description}</p>
+                <ul className="space-y-2 mb-8">
+                  {plan.features.map((f, j) => (
+                    <li key={j} className="text-sm text-base-content/50 flex items-start gap-2">
+                      <svg className="w-4 h-4 text-primary/60 shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                      <span>{f.name}</span>
+                    </li>
+                  ))}
+                </ul>
+                <ButtonCheckout priceId={plan.priceId} ctaButtonText={plan.ctaButtonText} openModal={openModal} />
+              </div>
+            </RevealSection>
+          ))}
+        </div>
+
+        <RevealSection className="mt-16 text-center">
+          <p className="text-base-content/30">
+            Need something different?{" "}
+            <button
+              className="text-primary hover:underline"
+              onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+            >
+              Let&apos;s talk →
+            </button>
+          </p>
+        </RevealSection>
+      </div>
+    </section>
+  );
+}
+
+// ─── FAQ ──────────────────────────────────────────────────────────
+function ChapterFAQ() {
+  const [openIndex, setOpenIndex] = useState(null);
+  return (
+    <section className="py-24 md:py-32 bg-base-200 px-8" id="faq-story">
+      <div className="max-w-3xl mx-auto">
+        <RevealSection>
+          <h2 className="text-4xl font-black tracking-tight mb-16 text-center">
+            Frequently Asked Questions
+          </h2>
+        </RevealSection>
+
+        <div>
+          {faqList.map((item, i) => (
+            <RevealSection key={i}>
+              <div className="border-b border-base-300">
+                <button
+                  className="w-full py-6 flex items-center justify-between text-left text-lg font-medium hover:text-primary transition-colors"
+                  onClick={() => setOpenIndex(openIndex === i ? null : i)}
+                >
+                  <span className="pr-4">{item.question}</span>
+                  <motion.span
+                    animate={{ rotate: openIndex === i ? 180 : 0 }}
+                    transition={{ duration: 0.3 }}
+                  >
+                    <svg className="w-5 h-5 text-base-content/30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </motion.span>
+                </button>
+                <div className={`overflow-hidden transition-all duration-500 ${openIndex === i ? "max-h-40 pb-6" : "max-h-0"}`}>
+                  <p className="text-base-content/40 leading-relaxed">{item.answer}</p>
+                </div>
+              </div>
+            </RevealSection>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FINAL CTA ────────────────────────────────────────────────────
+function ChapterCTA({ openModal }) {
+  return (
+    <section className="min-h-[70vh] flex items-center justify-center px-8 relative overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-t from-neutral via-neutral/95 to-base-100" />
+      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-gradient-radial from-primary/10 via-transparent to-transparent rounded-full blur-3xl" />
+
+      <RevealSection className="relative z-10 text-center max-w-3xl mx-auto">
+        <h2 className="text-5xl md:text-7xl font-black text-neutral-content tracking-tight leading-[0.95] mb-8">
+          Ready to write
+          <br />
+          <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#0066CC] to-[#FFCC00]">
+            your chapter?
+          </span>
+        </h2>
+        <p className="text-neutral-content/40 text-xl mb-12">
+          Let&apos;s talk about your project. No strings attached.
+        </p>
+        <button
+          className="btn btn-primary btn-lg px-12"
+          onClick={() => openModal(<div className="w-full max-w-md mx-auto"><ButtonLead /></div>)}
+        >
+          Start the conversation
+        </button>
+      </RevealSection>
+    </section>
+  );
+}
+
+// ─── MAIN PAGE ────────────────────────────────────────────────────
+export default function Concept5() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalContent, setModalContent] = useState(null);
+  const [modalTitle, setModalTitle] = useState("");
+
+  const openModal = (content, title) => {
+    setModalContent(content);
+    setModalTitle(title || "");
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <Suspense><Header openModal={openModal} /></Suspense>
+      <main>
+        <ChapterHero />
+        <ChapterPromise />
+        <ChapterProblem />
+        <ChapterSolution />
+        <ChapterProof />
+        <ChapterFounder />
+        <ChapterTools />
+        <ChapterPricing openModal={openModal} />
+        <ChapterFAQ />
+        <ChapterCTA openModal={openModal} />
+        <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} title={modalTitle}>
+          {modalContent}
+        </Modal>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/concepts/page.js
+++ b/app/concepts/page.js
@@ -1,0 +1,132 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+/*
+ * Concept Index: Navigate between all five homepage redesign concepts.
+ * Visit /concepts to see the overview, then click through to each design.
+ */
+
+const concepts = [
+  {
+    id: 1,
+    title: "Bold Split-Screen",
+    description: "Asymmetric layouts, dramatic split-screen sections, oversized typography, and bold color blocking. Each section uses a left/right split with content on one side and visuals on the other.",
+    inspiration: "Huge Inc, Rally, Collins",
+    color: "from-blue-600 to-yellow-500",
+    highlights: ["Full-viewport split panels", "Floating stat cards", "Dark/light contrast", "Marquee testimonials"],
+  },
+  {
+    id: 2,
+    title: "Minimalist Editorial",
+    description: "Clean whitespace, ultra-light typography, single-column centered layout, and a muted palette with one accent color. Content breathes with generous padding.",
+    inspiration: "Apple Marketing, Stripe, Editorial Magazines",
+    color: "from-gray-400 to-gray-600",
+    highlights: ["Ultra-light font weights", "Numbered sections", "Featured quote block", "Centered single-column"],
+  },
+  {
+    id: 3,
+    title: "Bento Grid Dashboard",
+    description: "Everything is a card in a bento-box grid with varying sizes. Rounded corners, subtle borders, and a cohesive dashboard feel throughout all sections.",
+    inspiration: "Linear, Vercel, Apple Bento",
+    color: "from-purple-500 to-pink-500",
+    highlights: ["Bento grid layout", "Card-based everything", "Gradient accent cards", "Modular composition"],
+  },
+  {
+    id: 4,
+    title: "Gradient Glassmorphism",
+    description: "Rich gradients, glassmorphism cards with backdrop blur, floating glowing orbs, and a premium dark aesthetic. Frosted glass panels over gradient backgrounds.",
+    inspiration: "Raycast, Arc Browser, Linear Dark",
+    color: "from-cyan-500 to-blue-600",
+    highlights: ["Frosted glass cards", "Background glow orbs", "Gradient text effects", "Status indicator pill"],
+  },
+  {
+    id: 5,
+    title: "Scroll-Reveal Storytelling",
+    description: "Full-viewport 'chapters' that reveal as you scroll. Dramatic parallax, narrative structure, and content that unfolds like a story with each scroll.",
+    inspiration: "Apple Product Pages, Stripe Annual Reports",
+    color: "from-orange-500 to-red-500",
+    highlights: ["Chapter-based narrative", "Parallax hero", "Scroll-triggered reveals", "Alternating testimonials"],
+  },
+];
+
+export default function ConceptsIndex() {
+  return (
+    <div className="min-h-screen bg-base-100 py-20 px-8">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-16">
+          <p className="text-primary text-sm tracking-widest uppercase font-medium mb-4">Homepage Redesign</p>
+          <h1 className="text-5xl md:text-7xl font-black tracking-tight mb-6">
+            5 Concepts
+          </h1>
+          <p className="text-base-content/50 text-lg max-w-xl mx-auto">
+            Five different design approaches for the Lansky Tech homepage. Same copy and content, completely different visual treatments. Click any concept to view it.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {concepts.map((concept, i) => (
+            <motion.div
+              key={concept.id}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.1 }}
+            >
+              <Link
+                href={`/concepts/${concept.id}`}
+                className="group block h-full rounded-2xl border border-base-300 bg-base-100 overflow-hidden hover:border-primary/30 hover:shadow-xl transition-all duration-300"
+              >
+                {/* Color bar */}
+                <div className={`h-2 bg-gradient-to-r ${concept.color}`} />
+
+                <div className="p-6">
+                  <div className="flex items-center gap-3 mb-4">
+                    <span className="text-base-content/20 text-4xl font-black">{String(concept.id).padStart(2, "0")}</span>
+                    <div>
+                      <h2 className="text-xl font-bold group-hover:text-primary transition-colors">{concept.title}</h2>
+                      <p className="text-xs text-base-content/30">Inspired by {concept.inspiration}</p>
+                    </div>
+                  </div>
+
+                  <p className="text-base-content/50 text-sm leading-relaxed mb-4">{concept.description}</p>
+
+                  <div className="flex flex-wrap gap-1.5">
+                    {concept.highlights.map((h) => (
+                      <span key={h} className="text-xs bg-base-200 text-base-content/50 px-2 py-1 rounded-full">{h}</span>
+                    ))}
+                  </div>
+
+                  <div className="mt-4 pt-4 border-t border-base-300/50 flex items-center justify-between">
+                    <span className="text-sm text-primary font-medium">View concept</span>
+                    <svg className="w-4 h-4 text-primary group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                    </svg>
+                  </div>
+                </div>
+              </Link>
+            </motion.div>
+          ))}
+
+          {/* Current design link */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5 }}
+          >
+            <Link
+              href="/"
+              className="group block h-full rounded-2xl border border-dashed border-base-300 bg-base-200/50 overflow-hidden hover:border-primary/30 transition-all duration-300"
+            >
+              <div className="p-6 flex flex-col items-center justify-center h-full text-center min-h-[200px]">
+                <p className="text-base-content/30 text-sm mb-2">For comparison</p>
+                <h2 className="text-xl font-bold group-hover:text-primary transition-colors mb-2">Current Homepage</h2>
+                <p className="text-base-content/40 text-sm">View the existing live design</p>
+              </div>
+            </Link>
+          </motion.div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Create five distinct homepage redesign approaches at /concepts:
1. Bold Split-Screen - Asymmetric layouts, floating cards, marquee
2. Minimalist Editorial - Ultra-light typography, single-column
3. Bento Grid Dashboard - Card-based modular composition
4. Gradient Glassmorphism - Frosted glass, glowing orbs, premium dark
5. Scroll-Reveal Storytelling - Chapter-based narrative, parallax

All concepts use existing copy/content with different visual treatments.
Includes /concepts index page for easy navigation between designs.

https://claude.ai/code/session_014XG9zrZ97jGc8YG5c4ngMu